### PR TITLE
feat(p2p-runtime): wrapped-key primitive (X25519 ECDH)

### DIFF
--- a/packages/p2p-runtime/src/wrap.ts
+++ b/packages/p2p-runtime/src/wrap.ts
@@ -1,0 +1,94 @@
+// Wrapped-key primitive: anonymous-sender public-key encryption.
+//
+// Used by the permissions model to deliver a symmetric key to a recipient whose
+// identity we know only by their ed25519 public key (the same key the
+// recipient's `did:key:z6Mk…` resolves to). The recipient unwraps with their
+// matching ed25519 secret key.
+//
+// Construction: sodium's crypto_box_seal — X25519 ECDH with an ephemeral
+// sender keypair, then XSalsa20-Poly1305 AEAD. The sender's identity is not
+// recoverable from the ciphertext; for our use case the sender's identity is
+// carried separately by the UCAN that travels alongside the wrapped key.
+//
+// Ed25519 ↔ curve25519 conversion is handled internally so callers pass
+// ed25519 keys (the form Hypercore + did:key already produce).
+
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sodium = require('sodium-universal') as any;
+
+const CURVE_PK_BYTES = sodium.crypto_box_PUBLICKEYBYTES as number;
+const CURVE_SK_BYTES = sodium.crypto_box_SECRETKEYBYTES as number;
+const SEAL_OVERHEAD = sodium.crypto_box_SEALBYTES as number;
+const ED_PK_BYTES = sodium.crypto_sign_PUBLICKEYBYTES as number;
+const ED_SK_BYTES = sodium.crypto_sign_SECRETKEYBYTES as number;
+
+/** Bytes added to plaintext by `wrap`. ciphertext.length === plaintext.length + WRAP_OVERHEAD. */
+export const WRAP_OVERHEAD: number = SEAL_OVERHEAD;
+
+/**
+ * Wrap arbitrary bytes for a recipient identified by an ed25519 public key.
+ *
+ * Typical use: encrypt a 32-byte symmetric key (e.g. `K0_org`) so only the
+ * holder of the matching ed25519 secret key can recover it. The sender is
+ * anonymous in the ciphertext — pair this with a UCAN if the sender's
+ * identity needs to be attestable.
+ */
+export function wrap(plaintext: Uint8Array, recipientEdPublicKey: Uint8Array): Uint8Array {
+  if (recipientEdPublicKey.length !== ED_PK_BYTES) {
+    throw new Error(
+      `recipient ed25519 public key must be ${ED_PK_BYTES} bytes, got ${recipientEdPublicKey.length}`,
+    );
+  }
+
+  const curvePk = Buffer.alloc(CURVE_PK_BYTES);
+  sodium.crypto_sign_ed25519_pk_to_curve25519(curvePk, Buffer.from(recipientEdPublicKey));
+
+  const sealed = Buffer.alloc(plaintext.length + SEAL_OVERHEAD);
+  sodium.crypto_box_seal(sealed, Buffer.from(plaintext), curvePk);
+  return new Uint8Array(sealed);
+}
+
+/**
+ * Unwrap a payload produced by `wrap`, using the recipient's ed25519 secret key
+ * (sodium's 64-byte form: 32-byte seed concatenated with the 32-byte public key,
+ * exactly what `hypercore-crypto.keyPair()` returns).
+ *
+ * Throws if the ciphertext was not addressed to this recipient or has been
+ * tampered with.
+ */
+export function unwrap(sealed: Uint8Array, recipientEdSecretKey: Uint8Array): Uint8Array {
+  if (recipientEdSecretKey.length !== ED_SK_BYTES) {
+    throw new Error(
+      `recipient ed25519 secret key must be ${ED_SK_BYTES} bytes ` +
+        `(sodium format: 32-byte seed + 32-byte pubkey), got ${recipientEdSecretKey.length}`,
+    );
+  }
+  if (sealed.length < SEAL_OVERHEAD) {
+    throw new Error(`sealed payload too short to be a wrap (got ${sealed.length} bytes, need ≥ ${SEAL_OVERHEAD})`);
+  }
+
+  // Sodium's ed25519 secret-key form is 32-byte seed || 32-byte pubkey.
+  const edPk = recipientEdSecretKey.subarray(32, 64);
+
+  const curvePk = Buffer.alloc(CURVE_PK_BYTES);
+  sodium.crypto_sign_ed25519_pk_to_curve25519(curvePk, Buffer.from(edPk));
+
+  const curveSk = Buffer.alloc(CURVE_SK_BYTES);
+  sodium.crypto_sign_ed25519_sk_to_curve25519(curveSk, Buffer.from(recipientEdSecretKey));
+
+  const plaintext = Buffer.alloc(sealed.length - SEAL_OVERHEAD);
+  const ok = sodium.crypto_box_seal_open(
+    plaintext,
+    Buffer.from(sealed),
+    curvePk,
+    curveSk,
+  ) as boolean;
+  if (!ok) {
+    throw new Error('unwrap failed — wrong recipient or tampered payload');
+  }
+  return new Uint8Array(plaintext);
+}

--- a/packages/p2p-runtime/tests/wrap.test.ts
+++ b/packages/p2p-runtime/tests/wrap.test.ts
@@ -1,0 +1,93 @@
+// Tests for the wrapped-key primitive (`src/wrap.ts`).
+//
+// Covers round-trip, length contract, non-determinism (fresh ephemeral key per
+// wrap), wrong-recipient rejection, tamper detection, edge cases (empty + large
+// plaintext), and input validation.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+import { wrap, unwrap, WRAP_OVERHEAD } from '../src/wrap.ts';
+
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const hypercoreCrypto = require('hypercore-crypto') as any;
+
+function keypair(): { publicKey: Buffer; secretKey: Buffer } {
+  return hypercoreCrypto.keyPair() as { publicKey: Buffer; secretKey: Buffer };
+}
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+test('round-trip: unwrap recovers the original plaintext', () => {
+  const recipient = keypair();
+  const wrapped = wrap(enc.encode('this is a secret'), recipient.publicKey);
+  const unwrapped = unwrap(wrapped, recipient.secretKey);
+  assert.equal(dec.decode(unwrapped), 'this is a secret');
+});
+
+test('output size: ciphertext is plaintext.length + WRAP_OVERHEAD', () => {
+  const recipient = keypair();
+  const plaintext = new Uint8Array(32);
+  crypto.getRandomValues(plaintext);
+  const wrapped = wrap(plaintext, recipient.publicKey);
+  assert.equal(wrapped.length, plaintext.length + WRAP_OVERHEAD);
+});
+
+test('non-deterministic: wrapping the same plaintext twice produces different ciphertext', () => {
+  const recipient = keypair();
+  const plaintext = enc.encode('same input');
+  const w1 = wrap(plaintext, recipient.publicKey);
+  const w2 = wrap(plaintext, recipient.publicKey);
+  assert.notDeepEqual(Array.from(w1), Array.from(w2));
+});
+
+test('wrong recipient: unwrap with a different secret key throws', () => {
+  const intended = keypair();
+  const attacker = keypair();
+  const wrapped = wrap(enc.encode('not for you'), intended.publicKey);
+  assert.throws(() => unwrap(wrapped, attacker.secretKey), /unwrap failed/);
+});
+
+test('tampered ciphertext: flipping one bit causes unwrap to throw', () => {
+  const recipient = keypair();
+  const wrapped = wrap(enc.encode('payload under test'), recipient.publicKey);
+  // Flip a bit in the AEAD-protected body, past the ephemeral pubkey (bytes 0..31).
+  const last = wrapped.length - 1;
+  wrapped[last] = wrapped[last]! ^ 0x01;
+  assert.throws(() => unwrap(wrapped, recipient.secretKey), /unwrap failed/);
+});
+
+test('empty plaintext round-trips and produces an OVERHEAD-only ciphertext', () => {
+  const recipient = keypair();
+  const wrapped = wrap(new Uint8Array(0), recipient.publicKey);
+  assert.equal(wrapped.length, WRAP_OVERHEAD);
+  const unwrapped = unwrap(wrapped, recipient.secretKey);
+  assert.equal(unwrapped.length, 0);
+});
+
+test('256-byte plaintext round-trips byte-for-byte', () => {
+  const recipient = keypair();
+  const plaintext = new Uint8Array(256);
+  crypto.getRandomValues(plaintext);
+  const wrapped = wrap(plaintext, recipient.publicKey);
+  const unwrapped = unwrap(wrapped, recipient.secretKey);
+  assert.deepEqual(Array.from(unwrapped), Array.from(plaintext));
+});
+
+test('wrap rejects a public key of wrong length', () => {
+  assert.throws(() => wrap(enc.encode('hi'), new Uint8Array(31)), /32 bytes/);
+});
+
+test('unwrap rejects a secret key of wrong length', () => {
+  const recipient = keypair();
+  const wrapped = wrap(enc.encode('hi'), recipient.publicKey);
+  assert.throws(() => unwrap(wrapped, new Uint8Array(32)), /64 bytes/);
+});
+
+test('unwrap rejects a sealed payload shorter than WRAP_OVERHEAD', () => {
+  const recipient = keypair();
+  assert.throws(() => unwrap(new Uint8Array(10), recipient.secretKey), /too short/);
+});


### PR DESCRIPTION
## Summary

Adds `wrap` / `unwrap` to `@workspace/p2p-runtime` — anonymous-sender public-key encryption for delivering a symmetric key to a recipient identified by their ed25519 public key (i.e. the key behind their `did:key:z6Mk…`).

This is the primitive at the heart of the key-delivery payload described in [`docs/permissions-model.md`](https://github.com/workspace-sh/workspace-p2p-spike/blob/develop/docs/permissions-model.md):

```
{
  ucan:        <signed delegation token>,
  wrapped_key: <symmetric key, sealed to recipient's public key>,
  resource:    <hypercore log address this key applies to>
}
```

`wrap` produces `wrapped_key`. `unwrap` recovers it. The UCAN and resource fields ride alongside; they are #8's territory.

## Construction

- `sodium-universal`'s `crypto_box_seal` — ephemeral sender keypair, X25519 ECDH, XSalsa20-Poly1305 AEAD
- Sender identity is not recoverable from the ciphertext (the UCAN carries it separately)
- Ed25519 ↔ curve25519 conversion is internal — callers pass ed25519 keys (the form Hypercore + did:key already produce)
- No new top-level dependency; `sodium-universal` is already transitive via Hypercore

## API

```ts
wrap(plaintext: Uint8Array, recipientEdPublicKey: Uint8Array): Uint8Array
unwrap(sealed: Uint8Array, recipientEdSecretKey: Uint8Array): Uint8Array
WRAP_OVERHEAD: number  // 48 bytes — sealed.length === plaintext.length + WRAP_OVERHEAD
```

## Tests (10 new, 25 total green)

- Round-trip
- Output size contract
- Non-determinism (fresh ephemeral key per `wrap`)
- Wrong recipient rejected
- Tampered ciphertext rejected
- Empty plaintext
- 256-byte plaintext
- Input validation (wrong-length public key, wrong-length secret key, too-short sealed payload)

## Pre-existing, out of scope

`npm run typecheck --workspace=packages/p2p-runtime` reports 4 errors that existed before this branch — three `react-native` module-not-found (RN types depend on consumer install) and one `MacOSRuntimeOptions` re-export collision in `runtime.macos.ts`. Worth filing as a follow-up; not part of this PR.

## Issue

Sub-issue of #5. Closes #7.

## Test plan

- [x] `npm test --workspace=packages/p2p-runtime` — 25/25 pass
- [x] `npm run typecheck --workspace=packages/p2p-runtime` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)