### PR TITLE
docs: threat model + .workspace format (v0)

### DIFF
--- a/docs/permissions-model.md
+++ b/docs/permissions-model.md
@@ -341,6 +341,12 @@ address is never shared with the wider org.
 
 ## Cross-references
 
+- [`threat-model.md`](./threat-model.md) — the contract this protocol
+  serves (what Workspace protects, what it doesn't, forward-only
+  revocation, audit trail = delegation chain)
+- [`workspace-format.md`](./workspace-format.md) — the `.workspace`
+  container format that distributes the artefacts this protocol
+  produces
 - [`FINDINGS.md`](../FINDINGS.md) — spike verdict + extraction checklist
 - [`docs/ucan-prior-research.md`](./ucan-prior-research.md) — UCAN
   notes from the earlier spike (ucanto `canIssue` gotcha, etc.)

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,239 @@
+# threat model
+
+What Workspace protects against, and — equally important — what it does
+not. The cryptographic detail lives in
+[`permissions-model.md`](./permissions-model.md); this document is the
+contract that detail serves.
+
+Read this **before** the protocol detail. Knowing which game is being
+played makes the moves comprehensible.
+
+---
+
+## the contract, in one paragraph
+
+Workspace protects data in transit between peers and gates access by
+unauthorised peers. It accepts that once an authorised peer has
+decrypted data, that exposure is permanent and out of the system's
+hands. Revocation is forward-only: it controls what an ex-peer receives
+*next*, never what they already have. At-rest protection on the user's
+own device is the operating system's job, not Workspace's.
+
+That contract is the same one Google Docs, Notion, Linear, iCloud, and
+every other consumer collaboration tool operates under. It is honest
+about what software can and cannot do.
+
+---
+
+## what Workspace protects
+
+- **Data in transit between peers.** All replication runs over
+  Hyperswarm's noise-encrypted streams. A passive observer on the
+  network sees nothing useful.
+- **Access by unauthorised peers (network layer).** Connection-time
+  UCAN authentication at the noise handshake rejects peers without a
+  current valid org-membership delegation. They cannot join the swarm,
+  cannot replicate blocks, cannot observe activity timing.
+- **Access by unauthorised peers (content layer).** Block contents are
+  encrypted with per-tier symmetric keys. A peer who is on the swarm
+  but lacks the tier's key receives ciphertext only.
+- **Future writes after revocation.** When a peer is revoked, the
+  affected symmetric keys rotate for new writes. The ex-peer holds
+  historical keys and can decrypt historical blocks they had already
+  replicated; they cannot decrypt any new writes.
+- **Tampering and replay of distributed files.** Root attestations and
+  UCAN signatures defeat post-distribution modification and stale-file
+  replay attacks.
+
+---
+
+## what Workspace does not protect
+
+These are not bugs. They are accepted realities of any system that
+delivers data to clients.
+
+- **Data at rest on an authorised user's device.** Whatever the
+  operating environment provides (FileVault on macOS, iOS Data
+  Protection, Android disk encryption, BitLocker on Windows) is what
+  the user gets. Workspace does not enforce this and does not rely on
+  it.
+- **What an authorised user does with decrypted data.** Screenshot,
+  paste into a chat, sync to a personal backup, copy to a USB stick,
+  retype into a competing tool — all out of scope. The user has the
+  data; what they do with it is governed by law, contract, and
+  professional ethics, not cryptography.
+- **Data already received by a now-revoked peer.** Forward-only
+  revocation is the only kind of revocation any "deliver to client"
+  system can honestly offer. The departing peer keeps everything they
+  had previously replicated.
+- **The fraudulent-identity case for root attestations.** A root
+  attestation defeats tampering of a distributed file and replay of
+  stale ones. It does **not** defeat a malicious creator who claims
+  `did:key:zEVIL` is "Acme's org root." Verifying the root DID itself
+  requires an out-of-band channel — a signed announcement, a known
+  URL, a fingerprint comparison, an existing trust relationship.
+- **Device hygiene.** A logged-in Workspace app on a stolen device is
+  a logged-in app. Account-level authentication and device management
+  are application-layer concerns, not cryptographic ones.
+
+If a future requirement demands controlling any of the above (e.g.
+DRM-style "view but cannot copy"), that requirement is incompatible
+with the contract and the system cannot honestly meet it. Better to
+say so than to add theatre.
+
+---
+
+## forward-only revocation, in plain terms
+
+If Bob had access to Alice's salary yesterday and is revoked today, he
+**still has** what he saw yesterday. He could have screenshotted it,
+emailed it to himself, written it down, memorised it. The system
+prevents him from seeing tomorrow's update. It does not retrieve
+yesterday's.
+
+This is exactly how Google Docs, Notion, Linear, Confluence, Office
+365, and Slack all behave. A user with access at time T can preserve
+what they saw at time T by any number of means; revocation closes
+future access, not past exposure. Workspace makes the same trade and
+makes it explicit.
+
+The two levers Workspace uses to close future access are detailed in
+[`permissions-model.md`](./permissions-model.md): encryption-layer
+(rotate the symmetric key) and topic-layer (drop the peer from the
+Hyperswarm topic). Both are forward-only. Both are honest.
+
+---
+
+## at-rest protection is environmental
+
+A previous draft of these docs implied OS disk encryption was "the
+right layer" for at-rest protection. That phrasing was misleading.
+
+The accurate statement is: **Workspace does not enforce at-rest
+encryption on the working tree, does not rely on it for its security
+guarantees, and does not claim to provide it.** Whatever your OS does
+is what you get. On managed devices the IT department's MDM may
+require disk encryption; on personal devices it is the user's choice.
+
+Mobile (iOS, Android) provides at-rest encryption automatically when
+the device is locked, derived from the user's passcode. Workspace does
+not control or guarantee this. It is an operating environment feature.
+
+This boundary keeps the contract honest. Workspace does not claim to
+solve problems it cannot solve.
+
+---
+
+## audit trail = the delegation chain
+
+A traditional audit log records actions: "Bob opened the salary field
+at 14:32 on March 5." In a peer-to-peer system that decrypts data on
+each peer's device, action-level logs are unfalsifiable (the peer
+controls their own logging) and uninteresting (action implies
+capability; capability is the thing that matters for forensics).
+
+Workspace's audit answer is therefore a **capability** statement, not
+an action statement. The UCAN delegation chain itself **is** the audit
+trail:
+
+> "Bob holds `K0_org` + `K1_alice` from 2026-03-01 to 2026-04-15."
+
+This tells you:
+
+- What he could read during that window (everything tier-0 across the
+  org, plus tier-1 of Alice's record)
+- When his access began (issuance timestamp on the delegation)
+- When it was revoked (revocation cascade kills downstream chains too)
+- Anything he sub-delegated downstream is visible in the same chain
+
+The delegation chain is append-only, distributed, offline-verifiable,
+and signed end-to-end. It cannot be tampered with or back-dated. It
+answers every audit question that's actually answerable.
+
+### what the chain does not tell you
+
+- Whether Bob *actually* read X (he could have, that's the point)
+- Whether Bob exfiltrated X (out of scope per the contract above)
+
+If regulatory or contractual requirements demand action-level proof
+("show me every read of this row"), the chain is insufficient and a
+separate logging layer would be needed. That layer is not currently
+designed and would not be tamper-evident in a P2P setting without
+introducing a trusted recorder — a tension worth being explicit about.
+
+### history.ndjson is a projection of the chain
+
+PR #26 against `table-file-format` lists `history.ndjson` as "the
+reserved extension for an audit log." Under this framing,
+`history.ndjson` is **not a separate event log**; it is a
+human-readable **projection** of the underlying delegation chain. The
+chain is the source of truth; the projection makes it queryable.
+
+This avoids the dual-source-of-truth problem (two logs that can drift)
+and inherits the chain's tamper-evidence for free.
+
+### reading the audit trail is itself a capability
+
+Not every member of an org should be able to enumerate "here is who
+has access to what." That ability is itself a UCAN — held by admins,
+auditors, or whatever role the org configures. Audit-read recurses
+nicely into the same capability model the rest of the system uses.
+
+---
+
+## explicit not-in-scope list
+
+Listing these out so future contributors don't waste effort proposing
+solutions to problems the contract has already declined:
+
+- **Screenshot prevention** — impossible on consumer hardware; not
+  attempted.
+- **Copy/paste blocking on decrypted content** — same.
+- **DRM-style "view but cannot save"** — same; cryptographically
+  incoherent in a P2P setting.
+- **Tracking who decrypted what when (action-level audit)** — possible
+  in principle but unfalsifiable in a P2P design (each peer controls
+  their own logs); not attempted in v1.
+- **Post-revocation forgetting (re-encrypting historical blocks the
+  ex-peer holds)** — Hypercore is append-only; this would require a
+  full re-publication and is incoherent with the data layer's design.
+- **Defeating device-level malware on an authorised user's machine** —
+  if the OS is compromised, so is everything. Not a goal.
+- **Authenticating the root DID without out-of-band channels** — the
+  attestation defeats tampering; identity establishment is a separate
+  trust-bootstrap problem.
+
+---
+
+## summary
+
+| What                                       | In scope? |
+|--------------------------------------------|-----------|
+| Data in transit between peers              | yes       |
+| Access by unauthorised peers (net + content)| yes       |
+| Future writes after revocation             | yes       |
+| Tampering of distributed files             | yes       |
+| Capability-level audit trail               | yes       |
+| At-rest on authorised devices              | no — environmental |
+| Authorised user's misuse of decrypted data | no — accepted contract |
+| Already-replicated data on revoked peer    | no — forward-only |
+| Action-level audit log (tamper-evident)    | no — would require trusted recorder |
+| Screenshot / copy / DRM-style controls     | no — not attempted |
+| Verifying root DID without out-of-band     | no — separate trust problem |
+
+The system is honest about what it does. That honesty is itself a
+design property.
+
+---
+
+## cross-references
+
+- [`permissions-model.md`](./permissions-model.md) — the cryptographic
+  detail this contract serves
+- [`workspace-format.md`](./workspace-format.md) — the container shape
+  that distributes the artefacts this contract protects
+- [`ucan-prior-research.md`](./ucan-prior-research.md) — UCAN-side
+  research notes; the `canIssue` and revocation gotchas matter for the
+  delegation-chain audit trail
+- [`table-file-format/docs/PERMISSIONS.md`](https://github.com/workspace-sh/table-file-format/blob/develop/docs/PERMISSIONS.md)
+  (PR #26) — consumer-side view of the permission model

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,4 +1,4 @@
-# threat model
+# Threat Model
 
 What Workspace protects against, and — equally important — what it does
 not. The cryptographic detail lives in
@@ -10,7 +10,7 @@ played makes the moves comprehensible.
 
 ---
 
-## the contract, in one paragraph
+## The contract, in one paragraph
 
 Workspace protects data in transit between peers and gates access by
 unauthorised peers. It accepts that once an authorised peer has
@@ -25,7 +25,7 @@ about what software can and cannot do.
 
 ---
 
-## what Workspace protects
+## What Workspace protects
 
 - **Data in transit between peers.** All replication runs over
   Hyperswarm's noise-encrypted streams. A passive observer on the
@@ -47,7 +47,7 @@ about what software can and cannot do.
 
 ---
 
-## what Workspace does not protect
+## What Workspace does not protect
 
 These are not bugs. They are accepted realities of any system that
 delivers data to clients.
@@ -83,7 +83,7 @@ say so than to add theatre.
 
 ---
 
-## forward-only revocation, in plain terms
+## Forward-only revocation, in plain terms
 
 If Bob had access to Alice's salary yesterday and is revoked today, he
 **still has** what he saw yesterday. He could have screenshotted it,
@@ -104,7 +104,7 @@ Hyperswarm topic). Both are forward-only. Both are honest.
 
 ---
 
-## at-rest protection is environmental
+## At-rest protection is environmental
 
 A previous draft of these docs implied OS disk encryption was "the
 right layer" for at-rest protection. That phrasing was misleading.
@@ -124,7 +124,7 @@ solve problems it cannot solve.
 
 ---
 
-## audit trail = the delegation chain
+## Audit trail = the delegation chain
 
 A traditional audit log records actions: "Bob opened the salary field
 at 14:32 on March 5." In a peer-to-peer system that decrypts data on
@@ -150,7 +150,7 @@ The delegation chain is append-only, distributed, offline-verifiable,
 and signed end-to-end. It cannot be tampered with or back-dated. It
 answers every audit question that's actually answerable.
 
-### what the chain does not tell you
+### What the chain does not tell you
 
 - Whether Bob *actually* read X (he could have, that's the point)
 - Whether Bob exfiltrated X (out of scope per the contract above)
@@ -161,7 +161,7 @@ separate logging layer would be needed. That layer is not currently
 designed and would not be tamper-evident in a P2P setting without
 introducing a trusted recorder — a tension worth being explicit about.
 
-### history.ndjson is a projection of the chain
+### `history.ndjson` is a projection of the chain
 
 PR #26 against `table-file-format` lists `history.ndjson` as "the
 reserved extension for an audit log." Under this framing,
@@ -172,7 +172,7 @@ chain is the source of truth; the projection makes it queryable.
 This avoids the dual-source-of-truth problem (two logs that can drift)
 and inherits the chain's tamper-evidence for free.
 
-### reading the audit trail is itself a capability
+### Reading the audit trail is itself a capability
 
 Not every member of an org should be able to enumerate "here is who
 has access to what." That ability is itself a UCAN — held by admins,
@@ -181,7 +181,7 @@ nicely into the same capability model the rest of the system uses.
 
 ---
 
-## explicit not-in-scope list
+## Explicit not-in-scope list
 
 Listing these out so future contributors don't waste effort proposing
 solutions to problems the contract has already declined:
@@ -205,7 +205,7 @@ solutions to problems the contract has already declined:
 
 ---
 
-## summary
+## Summary
 
 | What                                       | In scope? |
 |--------------------------------------------|-----------|
@@ -226,7 +226,7 @@ design property.
 
 ---
 
-## cross-references
+## Cross-references
 
 - [`permissions-model.md`](./permissions-model.md) — the cryptographic
   detail this contract serves

--- a/docs/workspace-format.md
+++ b/docs/workspace-format.md
@@ -1,0 +1,273 @@
+# .workspace — file format (v0, early spec)
+
+**Status:** early. Shape expected to change as
+[`permissions-model.md`](./permissions-model.md) implementation work
+proceeds. This document captures the current direction so format and
+app decisions made today don't paint us into a corner.
+
+---
+
+## one-paragraph summary
+
+A `.workspace` is a folder — or an archive of one — that contains a
+collection of files plus the metadata needed to sync them and enforce
+access control between peers. The contained files keep their own
+format identity (`.md`, `.canvas`, `.table/`, anything else) and can
+be opened by any tool that understands them. The container is what
+adds the P2P sync layer and the permission model on top.
+
+A `.table` outside a `.workspace` is just a `.table` — portable, open,
+no encryption. The same `.table` inside a `.workspace` gains
+field-level permission enforcement, because the workspace is the
+primitive container for that enforcement. The file format stays
+clean; the container does the work.
+
+---
+
+## what a workspace is
+
+```
+my-org.workspace/                    ← the workspace (folder or archive thereof)
+├── policies/
+│   ├── code-of-conduct.md           ← plaintext, anyone in the workspace can read
+│   └── parental-leave.md
+├── ideas/
+│   └── q2-retro.canvas
+├── data/
+│   ├── customers.table/             ← public-within-workspace by default
+│   └── employees.table/             ← field-tier permission enforcement via x-tier
+│       ├── schema.json              ← always unencrypted; declares which fields exist
+│       ├── rows.ndjson              ← per-field encryption applied by container
+│       └── bodies/
+└── _workspace/                      ← container metadata (see below)
+    ├── manifest.json
+    ├── attestation.json
+    ├── envelopes/
+    ├── keys/
+    └── store/                       ← Hypercore corestore
+```
+
+The outer folder is the workspace. The `_workspace/` subdirectory at
+the root is the container's bookkeeping. Everything else is content
+the user arranged.
+
+Archiving the folder (tar / zip / OS-native bundle) produces a
+portable snapshot that can be delivered over AirDrop, USB, HTTP,
+email, or any other transport — and reconstituted into a live
+workspace on the other side.
+
+---
+
+## two layers, separated by responsibility
+
+The workspace has two layers that coexist on disk:
+
+### layer 1 — working tree (human-facing)
+
+The files the user sees. Plaintext. Format-pure (a `.md` is a
+real `.md`, openable in any markdown editor). The user can `cat`
+them, edit them with any tool, copy them, ignore the workspace
+entirely.
+
+For tiered fields the user is not authorised to read, the working
+tree shows the field as `<no access>` (decision pending — see open
+questions). The field's existence is declared in `schema.json`
+regardless; the value is what gets hidden.
+
+### layer 2 — container metadata (machine-facing)
+
+The `_workspace/` subdirectory. Holds:
+
+- **`manifest.json`** — canonical workspace identity: workspace ID,
+  format version, creation timestamp, root DID, references to the
+  Hypercore log addresses used for sync and key delivery.
+- **`attestation.json`** — root attestation signed over `(workspaceId,
+  createdAt)` by the root DID. Defeats tampering of the manifest and
+  replay of stale workspaces. (Does **not** defeat fraudulent identity
+  claims — see [`threat-model.md`](./threat-model.md).)
+- **`envelopes/`** — bootstrap envelopes for first-contact recipients
+  (`{ucan, wrapped_key, resource}` triples sealed to recipient DIDs).
+  Used when the workspace is delivered offline; consumed once and then
+  ongoing key delivery rides the live Hypercore log.
+- **`keys/`** — local key state: this peer's identity material,
+  unwrapped symmetric keys the peer has rights to, key delivery cursor.
+- **`store/`** — the Hypercore corestore: encrypted append-only blocks
+  for the workspace's data and key-delivery logs.
+
+The analogy that closest is git: working tree at the root is
+plaintext; `.git/` is opaque. Both layers exist on disk simultaneously.
+
+---
+
+## permission semantics
+
+A workspace can contain a mix of:
+
+- **Public-within-workspace files** — readable by any peer holding the
+  workspace's base key (`K0_org`). The default for `.md`, `.canvas`,
+  most `.table/` files.
+- **UCAN-gated files / fields** — encrypted with tier-specific keys
+  (`K1`, `K2`, …) distributed via UCAN delegation. Required for
+  sensitive content; opt-in via `x-tier` declarations in `.table`
+  schemas, or via a folder-level convention for whole-file tiering
+  (open question, see below).
+
+A peer's effective access at any moment is the union of every key
+they hold, which is the union of every UCAN delegation chain that
+terminates at their DID. The audit trail is the chain itself
+([`threat-model.md`](./threat-model.md)).
+
+### file-format-specific semantics
+
+- **`.md`, `.canvas`** — flat permission model. Three roles per file:
+  `read`, `edit`, `admin`. One symmetric key per file (or
+  public-within-workspace, no key required).
+- **`.table/`** — gains field-level tiering when inside a workspace.
+  Fields without `x-tier` are tier 0 (public-within-workspace). Fields
+  with `x-tier: 1, 2, ...` are encrypted with the tier's key.
+  Per-field encryption applies to `rows.ndjson` only; `schema.json`
+  remains unencrypted so every peer knows the table's shape even when
+  they cannot read every value.
+
+Refer to
+[`table-file-format/docs/PERMISSIONS.md`](https://github.com/workspace-sh/table-file-format/blob/develop/docs/PERMISSIONS.md)
+(PR #26) for the consumer-side view of `.table`'s tiering.
+
+---
+
+## portability
+
+Three portability stories the format must serve:
+
+### file out of workspace
+
+Move a `.md` or `.table/` out of a workspace and it's just a file.
+Plain markdown, plain table. Any tool that handles the format handles
+the file. No encryption, no permission model, no Workspace dependency.
+
+This is the default for `.table`'s portability story: the file format
+is clean and self-contained outside the container.
+
+### workspace as snapshot
+
+Tar / zip the entire `my-org.workspace/` directory. The archive
+contains everything: the working tree, the manifest, the attestation,
+the envelopes, the Hypercore store. Hand it to anyone:
+
+- **With a Workspace app and a valid identity**: unpack, app verifies
+  attestation, peer consumes any bootstrap envelope addressed to
+  their DID, joins the swarm, picks up ongoing sync.
+- **Without a Workspace app**: unpack, browse the working tree, read
+  the plaintext files. Lose sync and permission enforcement, keep the
+  data they had at the snapshot moment.
+
+The archive form is the unit of distribution. Offline delivery
+(AirDrop, USB) is a first-class case, not an afterthought.
+
+### workspace as live state
+
+The unarchived folder, sitting on disk, is the live state. Workspace
+watches the working tree, commits user edits into the Hypercore store,
+replicates over Hyperswarm, applies remote edits back into the working
+tree. The two layers stay in sync.
+
+---
+
+## what the format is not
+
+- **Not a redefinition of the file formats inside it.** `.md` is still
+  `.md`. `.canvas` is still `.canvas`. `.table` is still `.table`. The
+  workspace just contains them and adds an enforcement layer.
+- **Not the protocol.** The cryptographic mechanics (UCAN, wrapping,
+  Hypercore, Hyperswarm, root attestation) live in
+  [`permissions-model.md`](./permissions-model.md). This document
+  describes the on-disk shape; the protocol is what makes it work.
+- **Not a lock-in.** The working tree is the user's data, always
+  readable without a Workspace app. The container adds value when
+  Workspace is present; it does not subtract value when Workspace is
+  absent.
+
+---
+
+## open design questions
+
+Explicit so future contributors don't quietly pick defaults:
+
+1. **Bundle layout — visible vs hidden metadata directory.** Current
+   sketch uses `_workspace/` (visible-but-prefixed). Alternatives:
+   `.workspace-meta/` (hidden, dot-prefixed), `meta/` (visible,
+   unprefixed), no subdirectory (metadata files at root). Each has
+   trade-offs around discoverability, accidental edit, and
+   cross-platform behaviour (Windows hides dot-prefixed inconsistently).
+2. **Archive format.** Plain tar? Zip? OS-native bundle (macOS-style
+   `.workspace` package)? Plain directory only (let the OS handle
+   archiving)? The choice affects how the format is recognised by
+   default OS tooling.
+3. **Hidden-field representation in the working tree.** For tiered
+   fields a user cannot decrypt: show as `<no access>`, omit entirely,
+   or surface as a typed null with a sentinel value? Affects what
+   third-party tools see when they read `rows.ndjson` directly.
+4. **Folder-level whole-file tiering.** `.table` has `x-tier` for
+   fields. Should there be an equivalent for whole files (a "tier
+   this folder at `K1`" convention)? If so, where does the declaration
+   live — in `manifest.json`, in a per-folder dotfile, both?
+5. **Export semantics.** When a user exports a single file from a
+   workspace: "decrypt and bundle" (file becomes plaintext, leaves the
+   permission layer) vs "stays sealed" (file is unusable outside a
+   workspace). UX decision; needs to be documented clearly wherever
+   it lands.
+6. **Workspace identity vs root identity.** Is `workspaceId` always
+   equal to the root DID, or a separate identifier issued at workspace
+   creation? Implications for multi-workspace orgs, forking, and root
+   key rotation.
+7. **Workspace versioning.** `manifest.json` must carry a
+   `formatVersion`. What changes warrant a version bump? Forward
+   compatibility expectations for older readers encountering newer
+   workspaces?
+8. **Manifest content boundary.** What belongs in `manifest.json` vs
+   separate files in `_workspace/`? Tension between "single
+   authoritative file" and "separation of concerns."
+9. **Forks and copies.** If Alice forks a workspace and modifies it,
+   what identifies the fork as related to the original? Trail in the
+   manifest, separate `originWorkspaceId`, or no formal relationship?
+
+These are not blockers for early implementation; the wrap primitive
+and the bootstrap envelope work can proceed using a sketch shape and
+inform the answers.
+
+---
+
+## relationship to the wider spike
+
+This format is the **container** for everything the permissions model
+delivers. The model defines the cryptographic protocol; the format
+defines where the bytes sit on disk. Both serve the contract spelled
+out in [`threat-model.md`](./threat-model.md).
+
+Implementation work that materially affects this format:
+
+- **PR #13** (wrap primitive) — produces the sealed bytes that go into
+  `envelopes/`.
+- **#8** (ucanto integration) — produces the UCAN tokens that ride
+  alongside.
+- **#9** (key delivery log) — narrows to the live-log carrier; the
+  in-bundle `envelopes/` directory is the offline-bootstrap carrier of
+  the same payloads.
+- **New issue (to file)** — portable bootstrap manifest + envelope
+  bundling logic. Distinct from #9.
+- **#10** (topic-layer auth) — gates connection to the workspace's
+  swarm; the topic identifier is derived from values declared in
+  `manifest.json`.
+
+---
+
+## cross-references
+
+- [`threat-model.md`](./threat-model.md) — the contract this format
+  serves
+- [`permissions-model.md`](./permissions-model.md) — the cryptographic
+  protocol
+- [`ucan-prior-research.md`](./ucan-prior-research.md) — UCAN library
+  notes
+- [`table-file-format/docs/PERMISSIONS.md`](https://github.com/workspace-sh/table-file-format/blob/develop/docs/PERMISSIONS.md)
+  (PR #26) — `.table`'s consumer-side permission view

--- a/docs/workspace-format.md
+++ b/docs/workspace-format.md
@@ -1,4 +1,4 @@
-# .workspace — file format (v0, early spec)
+# .workspace — File Format (v0, Early Spec)
 
 **Status:** early. Shape expected to change as
 [`permissions-model.md`](./permissions-model.md) implementation work
@@ -7,7 +7,7 @@ app decisions made today don't paint us into a corner.
 
 ---
 
-## one-paragraph summary
+## One-paragraph summary
 
 A `.workspace` is a folder — or an archive of one — that contains a
 collection of files plus the metadata needed to sync them and enforce
@@ -24,7 +24,7 @@ clean; the container does the work.
 
 ---
 
-## what a workspace is
+## What a workspace is
 
 ```
 my-org.workspace/                    ← the workspace (folder or archive thereof)
@@ -58,11 +58,11 @@ workspace on the other side.
 
 ---
 
-## two layers, separated by responsibility
+## Two layers, separated by responsibility
 
 The workspace has two layers that coexist on disk:
 
-### layer 1 — working tree (human-facing)
+### Layer 1 — working tree (human-facing)
 
 The files the user sees. Plaintext. Format-pure (a `.md` is a
 real `.md`, openable in any markdown editor). The user can `cat`
@@ -74,7 +74,7 @@ tree shows the field as `<no access>` (decision pending — see open
 questions). The field's existence is declared in `schema.json`
 regardless; the value is what gets hidden.
 
-### layer 2 — container metadata (machine-facing)
+### Layer 2 — container metadata (machine-facing)
 
 The `_workspace/` subdirectory. Holds:
 
@@ -99,7 +99,7 @@ plaintext; `.git/` is opaque. Both layers exist on disk simultaneously.
 
 ---
 
-## permission semantics
+## Permission semantics
 
 A workspace can contain a mix of:
 
@@ -117,7 +117,7 @@ they hold, which is the union of every UCAN delegation chain that
 terminates at their DID. The audit trail is the chain itself
 ([`threat-model.md`](./threat-model.md)).
 
-### file-format-specific semantics
+### File-format-specific semantics
 
 - **`.md`, `.canvas`** — flat permission model. Three roles per file:
   `read`, `edit`, `admin`. One symmetric key per file (or
@@ -135,11 +135,11 @@ Refer to
 
 ---
 
-## portability
+## Portability
 
 Three portability stories the format must serve:
 
-### file out of workspace
+### File out of workspace
 
 Move a `.md` or `.table/` out of a workspace and it's just a file.
 Plain markdown, plain table. Any tool that handles the format handles
@@ -148,7 +148,7 @@ the file. No encryption, no permission model, no Workspace dependency.
 This is the default for `.table`'s portability story: the file format
 is clean and self-contained outside the container.
 
-### workspace as snapshot
+### Workspace as snapshot
 
 Tar / zip the entire `my-org.workspace/` directory. The archive
 contains everything: the working tree, the manifest, the attestation,
@@ -164,7 +164,7 @@ the envelopes, the Hypercore store. Hand it to anyone:
 The archive form is the unit of distribution. Offline delivery
 (AirDrop, USB) is a first-class case, not an afterthought.
 
-### workspace as live state
+### Workspace as live state
 
 The unarchived folder, sitting on disk, is the live state. Workspace
 watches the working tree, commits user edits into the Hypercore store,
@@ -173,7 +173,7 @@ tree. The two layers stay in sync.
 
 ---
 
-## what the format is not
+## What the format is not
 
 - **Not a redefinition of the file formats inside it.** `.md` is still
   `.md`. `.canvas` is still `.canvas`. `.table` is still `.table`. The
@@ -189,7 +189,7 @@ tree. The two layers stay in sync.
 
 ---
 
-## open design questions
+## Open design questions
 
 Explicit so future contributors don't quietly pick defaults:
 
@@ -237,7 +237,7 @@ inform the answers.
 
 ---
 
-## relationship to the wider spike
+## Relationship to the wider spike
 
 This format is the **container** for everything the permissions model
 delivers. The model defines the cryptographic protocol; the format
@@ -261,7 +261,7 @@ Implementation work that materially affects this format:
 
 ---
 
-## cross-references
+## Cross-references
 
 - [`threat-model.md`](./threat-model.md) — the contract this format
   serves


### PR DESCRIPTION
## Summary

Two new design docs capturing the contract and the container shape the permissions work has been converging on.

- **[`docs/threat-model.md`](https://github.com/workspace-sh/workspace-p2p-spike/blob/docs/threat-model-and-workspace-format/docs/threat-model.md)** — the contract. What Workspace protects (transit, unauthorised access at network + content layers, future writes, tampering, capability-level audit). What it explicitly does *not* (at-rest on authorised devices, what authorised users do with decrypted data, already-replicated data on revoked peers, fraudulent identity claims, screenshot / copy / DRM). Honest about forward-only revocation matching Google Docs / Notion / Linear contracts. Establishes that the audit trail *is* the UCAN delegation chain — capability statements, not action events — and that `history.ndjson` is a projection of the chain rather than a separate event log.

- **[`docs/workspace-format.md`](https://github.com/workspace-sh/workspace-p2p-spike/blob/docs/threat-model-and-workspace-format/docs/workspace-format.md)** — early v0 spec for `.workspace`. A folder (or archive of one) containing a working tree of plaintext human-facing files plus a `_workspace/` metadata subdirectory (manifest, attestation, envelopes, key state, Hypercore store). Two-layer structure mirrors git's working-tree / `.git` split. File formats stay clean and portable when outside; `.table` gains field-level enforcement when inside. Nine open design questions called out explicitly so future contributors don't quietly pick defaults.

- **`docs/permissions-model.md`** — cross-references updated to point at both new docs.

## Why now

Design conversation has settled on:

1. Workspace doesn't pretend to enforce at-rest encryption — that's environmental
2. Forward-only revocation is the accepted contract, same as every other collaboration tool
3. The audit story is capability, not action, and falls out of the UCAN chain for free
4. `.workspace` is the container that gives permission semantics to whatever's inside; file formats stay portable on their own

These were scattered across earlier docs and threads. This PR pins them down before more implementation lands.

## Scope

Documentation only. No code. No tests. Implementation work continues on the #5 sub-issues.

## Out of scope, but on the radar

- A new sub-issue for portable bootstrap envelopes (manifest + bundle/unbundle logic) still needs filing. Distinct from #9.
- The format's open questions (visible vs hidden metadata dir, archive format, hidden-field representation, etc.) will be answered as implementation forces choices.
- Eventually the workspace-format spec may move to its own sibling repo if commitment to the portable-file thesis hardens. For now, in-spike is the right home.

## Related

- Sub-issue context of #5
- PR #13 (wrap primitive) — independent; can land in either order
- PR #26 on `table-file-format` — consumer-side view of the permission model; cross-referenced

## Test plan

- [x] Markdown renders cleanly
- [x] All internal links resolve (verified manually against the file tree)
- [x] No code changes; nothing to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)