### PR TITLE
feat(p2p-runtime): root attestation primitive

### DIFF
--- a/packages/p2p-runtime/src/attestation.ts
+++ b/packages/p2p-runtime/src/attestation.ts
@@ -1,0 +1,184 @@
+// Root attestation for portable Workspace bundles.
+//
+// A root attestation is a signature by the workspace's root DID over a small
+// canonical payload binding workspace identity to creation time. It defeats:
+//
+//   - Tampering of the manifest after distribution
+//   - Replay of stale workspaces (e.g. resurrecting a deleted org)
+//
+// It does **not** defeat fraudulent identity claims — verifying that a given
+// `did:key:zABC…` is genuinely "Acme's org root" still requires an
+// out-of-band channel (signed announcement, well-known URL, fingerprint
+// comparison). See `docs/threat-model.md` for the explicit framing.
+//
+// The signature lineage is ed25519 via `hypercore-crypto`, the same algorithm
+// used by ucanto's @noble/ed25519. Signatures produced here can be verified
+// by either implementation (and vice versa).
+
+import { createRequire } from 'node:module';
+import type { Did } from './types.ts';
+import { didFromPublicKey, publicKeyFromDid } from './did.ts';
+
+const require = createRequire(import.meta.url);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const hypercoreCrypto = require('hypercore-crypto') as any;
+
+// ---------------------------------------------------------------------------
+// Low-level: sign/verify arbitrary bytes with an ed25519 keypair
+// ---------------------------------------------------------------------------
+
+/**
+ * Sign arbitrary bytes with an ed25519 secret key.
+ *
+ * @param message    Bytes to sign
+ * @param secretKey  64-byte ed25519 secret key (sodium format: 32-byte seed || 32-byte pubkey)
+ * @returns          64-byte ed25519 signature
+ */
+export function sign(message: Uint8Array, secretKey: Uint8Array): Uint8Array {
+  if (secretKey.length !== 64) {
+    throw new Error(
+      `ed25519 secret key must be 64 bytes (sodium format: 32-byte seed + 32-byte pubkey), got ${secretKey.length}`,
+    );
+  }
+  const sig = hypercoreCrypto.sign(Buffer.from(message), Buffer.from(secretKey)) as Buffer;
+  return new Uint8Array(sig);
+}
+
+/**
+ * Verify an ed25519 signature against the given public key.
+ *
+ * @returns true if the signature is valid; false otherwise.
+ */
+export function verify(
+  message: Uint8Array,
+  signature: Uint8Array,
+  publicKey: Uint8Array,
+): boolean {
+  if (publicKey.length !== 32) {
+    throw new Error(`ed25519 public key must be 32 bytes, got ${publicKey.length}`);
+  }
+  if (signature.length !== 64) {
+    throw new Error(`ed25519 signature must be 64 bytes, got ${signature.length}`);
+  }
+  return hypercoreCrypto.verify(
+    Buffer.from(message),
+    Buffer.from(signature),
+    Buffer.from(publicKey),
+  ) as boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Workspace attestation
+// ---------------------------------------------------------------------------
+
+/** The payload signed by the root DID. */
+export interface AttestationPayload {
+  /** Stable workspace identifier (e.g. a UUIDv4 or a content-derived hash). */
+  workspaceId: string;
+  /** Workspace creation time, whole-seconds-since-epoch. */
+  createdAt: number;
+  /** `_workspace/` format version this attestation was issued under. */
+  formatVersion: number;
+}
+
+/** A signed attestation, suitable for persistence and offline verification. */
+export interface SignedAttestation {
+  /** Convenience: the parsed payload. */
+  payload: AttestationPayload;
+  /** Canonical bytes that were signed. Re-computable from `payload`. */
+  payloadBytes: Uint8Array;
+  /** 64-byte ed25519 signature. */
+  signature: Uint8Array;
+  /** `did:key:z…` of the signer. The verifier extracts the public key from this. */
+  rootDid: Did;
+}
+
+/**
+ * Produce the canonical bytes for an attestation payload.
+ *
+ * Canonicalisation rule for v1: explicit field order (alphabetical), no
+ * whitespace, UTF-8 encoded JSON. Sufficient because the payload shape is
+ * fixed; if the payload ever grows nested or open-ended, switch to a proper
+ * canonical-JSON or CBOR encoding.
+ */
+export function buildAttestationPayload(p: AttestationPayload): Uint8Array {
+  // Explicit alphabetical key order — do NOT rely on object literal order.
+  const canonical = `{"createdAt":${Math.floor(p.createdAt)},"formatVersion":${
+    p.formatVersion
+  },"workspaceId":${JSON.stringify(p.workspaceId)}}`;
+  return new TextEncoder().encode(canonical);
+}
+
+/**
+ * Sign a workspace attestation with the root's ed25519 secret key.
+ *
+ * The `rootDid` field is derived from the secret key's embedded public key,
+ * so the caller does not need to pass it separately.
+ */
+export function signWorkspaceAttestation(
+  payload: AttestationPayload,
+  rootSecretKey: Uint8Array,
+): SignedAttestation {
+  if (rootSecretKey.length !== 64) {
+    throw new Error(
+      `ed25519 secret key must be 64 bytes (sodium format), got ${rootSecretKey.length}`,
+    );
+  }
+  const payloadBytes = buildAttestationPayload(payload);
+  const signature = sign(payloadBytes, rootSecretKey);
+  // Sodium-format secret key: bytes 32..64 are the public key.
+  const rootPublicKey = rootSecretKey.subarray(32, 64);
+  const rootDid = didFromPublicKey(rootPublicKey);
+  return {
+    payload: {
+      workspaceId: payload.workspaceId,
+      createdAt: Math.floor(payload.createdAt),
+      formatVersion: payload.formatVersion,
+    },
+    payloadBytes,
+    signature,
+    rootDid,
+  };
+}
+
+/**
+ * Verify a workspace attestation: re-compute the canonical payload bytes
+ * from `att.payload`, decode the root DID to a public key, and check the
+ * signature.
+ *
+ * Returns `true` only if the payload matches what was signed AND the
+ * signature is valid against the claimed root DID. Returns `false` for any
+ * mismatch (tampered payload, tampered signature, wrong-key claim).
+ *
+ * Caveat: this does not prove that `rootDid` belongs to the legitimate
+ * workspace owner. That trust comes from an out-of-band channel — see
+ * `docs/threat-model.md` "What Workspace does not protect."
+ */
+export function verifyWorkspaceAttestation(att: SignedAttestation): boolean {
+  // Re-derive the canonical payload bytes and ensure they match what's stored.
+  // (If att.payloadBytes was tampered with, the signature would fail anyway,
+  // but this catches mismatches earlier and produces a clearer "tampered
+  // payload" outcome.)
+  const recomputed = buildAttestationPayload(att.payload);
+  if (
+    recomputed.length !== att.payloadBytes.length ||
+    !uint8ArraysEqual(recomputed, att.payloadBytes)
+  ) {
+    return false;
+  }
+  const publicKey = publicKeyFromDid(att.rootDid);
+  return verify(att.payloadBytes, att.signature, publicKey);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function uint8ArraysEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}

--- a/packages/p2p-runtime/src/did.ts
+++ b/packages/p2p-runtime/src/did.ts
@@ -61,6 +61,38 @@ function base58btcEncode(bytes: Uint8Array): string {
   );
 }
 
+function base58btcDecode(str: string): Uint8Array {
+  // Count leading '1's (each maps to a leading zero byte).
+  let leadingOnes = 0;
+  for (const ch of str) {
+    if (ch !== '1') break;
+    leadingOnes++;
+  }
+
+  // Convert the base58 digits to bytes via repeated multiplication.
+  const bytes: number[] = [];
+  for (let i = leadingOnes; i < str.length; i++) {
+    const ch = str[i]!;
+    const digit = BASE58_ALPHABET.indexOf(ch);
+    if (digit < 0) throw new Error(`invalid base58btc character: ${ch}`);
+    let carry = digit;
+    for (let j = 0; j < bytes.length; j++) {
+      carry += bytes[j]! * 58;
+      bytes[j] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+
+  // Add leading zero bytes for each leading '1'.
+  const out = new Uint8Array(leadingOnes + bytes.length);
+  out.set(bytes.reverse(), leadingOnes);
+  return out;
+}
+
 // ---------------------------------------------------------------------------
 // ed25519 multicodec prefix (varint): 0xed 0x01
 // ---------------------------------------------------------------------------
@@ -82,11 +114,44 @@ export function didFromSeed(seed: Uint8Array): Did {
     publicKey: Buffer;
     secretKey: Buffer;
   };
+  return didFromPublicKey(kp.publicKey);
+}
 
-  // Prepend multicodec prefix to the 32-byte public key.
-  const prefixed = new Uint8Array(ED25519_PUB_MULTICODEC.length + kp.publicKey.length);
+/**
+ * Encode a 32-byte ed25519 public key as a `did:key:z6Mk…` string.
+ *
+ * Used when you already have the public key (e.g. from a signer's keypair)
+ * and don't need to re-derive it from a seed.
+ */
+export function didFromPublicKey(publicKey: Uint8Array): Did {
+  if (publicKey.length !== 32) {
+    throw new Error(`ed25519 public key must be 32 bytes, got ${publicKey.length}`);
+  }
+  const prefixed = new Uint8Array(ED25519_PUB_MULTICODEC.length + publicKey.length);
   prefixed.set(ED25519_PUB_MULTICODEC, 0);
-  prefixed.set(kp.publicKey, ED25519_PUB_MULTICODEC.length);
-
+  prefixed.set(publicKey, ED25519_PUB_MULTICODEC.length);
   return `did:key:z${base58btcEncode(prefixed)}` as Did;
+}
+
+/**
+ * Inverse of `didFromPublicKey`: decode a `did:key:z6Mk…` to its 32-byte
+ * ed25519 public key.
+ *
+ * Throws if the input is not a `did:key:z…` ed25519 DID.
+ */
+export function publicKeyFromDid(did: Did): Uint8Array {
+  if (!did.startsWith('did:key:z')) {
+    throw new Error(`not a did:key:z… DID: ${did}`);
+  }
+  const decoded = base58btcDecode(did.slice('did:key:z'.length));
+  if (decoded.length < ED25519_PUB_MULTICODEC.length) {
+    throw new Error('decoded DID is too short to carry an ed25519 multicodec prefix');
+  }
+  if (
+    decoded[0] !== ED25519_PUB_MULTICODEC[0] ||
+    decoded[1] !== ED25519_PUB_MULTICODEC[1]
+  ) {
+    throw new Error('DID multicodec prefix does not match ed25519-pub (0xed 0x01)');
+  }
+  return decoded.subarray(ED25519_PUB_MULTICODEC.length);
 }

--- a/packages/p2p-runtime/tests/attestation.test.ts
+++ b/packages/p2p-runtime/tests/attestation.test.ts
@@ -1,0 +1,231 @@
+// Tests for src/attestation.ts.
+//
+// Covers low-level sign/verify (round-trip, wrong-key rejection, tamper
+// detection on payload and signature, input validation) and the workspace-
+// attestation flow (canonical-payload determinism, sign + verify round-trip,
+// rootDid derivation, tampered-field rejection).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+import {
+  sign,
+  verify,
+  buildAttestationPayload,
+  signWorkspaceAttestation,
+  verifyWorkspaceAttestation,
+  type AttestationPayload,
+} from '../src/attestation.ts';
+import { didFromSeed, publicKeyFromDid } from '../src/did.ts';
+
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const hypercoreCrypto = require('hypercore-crypto') as any;
+
+function keypair(): { publicKey: Buffer; secretKey: Buffer } {
+  return hypercoreCrypto.keyPair() as { publicKey: Buffer; secretKey: Buffer };
+}
+
+const enc = new TextEncoder();
+
+// ---------------------------------------------------------------------------
+// Low-level sign/verify
+// ---------------------------------------------------------------------------
+
+test('sign/verify: round-trip succeeds with the right keypair', () => {
+  const kp = keypair();
+  const sig = sign(enc.encode('payload'), kp.secretKey);
+  assert.equal(sig.length, 64);
+  assert.equal(verify(enc.encode('payload'), sig, kp.publicKey), true);
+});
+
+test('sign/verify: wrong public key rejects', () => {
+  const a = keypair();
+  const b = keypair();
+  const sig = sign(enc.encode('hello'), a.secretKey);
+  assert.equal(verify(enc.encode('hello'), sig, b.publicKey), false);
+});
+
+test('sign/verify: tampered message rejects', () => {
+  const kp = keypair();
+  const sig = sign(enc.encode('original'), kp.secretKey);
+  assert.equal(verify(enc.encode('tampered'), sig, kp.publicKey), false);
+});
+
+test('sign/verify: tampered signature rejects', () => {
+  const kp = keypair();
+  const sig = sign(enc.encode('payload'), kp.secretKey);
+  const tampered = new Uint8Array(sig);
+  tampered[0] = tampered[0]! ^ 0x01;
+  assert.equal(verify(enc.encode('payload'), tampered, kp.publicKey), false);
+});
+
+test('sign rejects secret key of wrong length', () => {
+  assert.throws(() => sign(enc.encode('x'), new Uint8Array(32)), /64 bytes/);
+});
+
+test('verify rejects public key of wrong length', () => {
+  const kp = keypair();
+  const sig = sign(enc.encode('x'), kp.secretKey);
+  assert.throws(() => verify(enc.encode('x'), sig, new Uint8Array(31)), /32 bytes/);
+});
+
+test('verify rejects signature of wrong length', () => {
+  const kp = keypair();
+  assert.throws(() => verify(enc.encode('x'), new Uint8Array(63), kp.publicKey), /64 bytes/);
+});
+
+// ---------------------------------------------------------------------------
+// Canonical payload determinism
+// ---------------------------------------------------------------------------
+
+test('canonical payload: same input always produces same bytes', () => {
+  const p: AttestationPayload = { workspaceId: 'wid-1', createdAt: 1717200000, formatVersion: 1 };
+  const a = buildAttestationPayload(p);
+  const b = buildAttestationPayload(p);
+  assert.deepEqual(Array.from(a), Array.from(b));
+});
+
+test('canonical payload: field order in input does not matter', () => {
+  const a = buildAttestationPayload({
+    workspaceId: 'wid-1',
+    createdAt: 1717200000,
+    formatVersion: 1,
+  });
+  const b = buildAttestationPayload({
+    formatVersion: 1,
+    workspaceId: 'wid-1',
+    createdAt: 1717200000,
+  });
+  assert.deepEqual(Array.from(a), Array.from(b));
+});
+
+test('canonical payload: keys are alphabetically ordered in the output', () => {
+  const bytes = buildAttestationPayload({
+    workspaceId: 'wid',
+    createdAt: 100,
+    formatVersion: 1,
+  });
+  const str = new TextDecoder().decode(bytes);
+  // Expected exact form (no whitespace, sorted keys).
+  assert.equal(str, '{"createdAt":100,"formatVersion":1,"workspaceId":"wid"}');
+});
+
+test('canonical payload: createdAt is floored to whole seconds', () => {
+  const bytes = buildAttestationPayload({
+    workspaceId: 'wid',
+    createdAt: 100.9,
+    formatVersion: 1,
+  });
+  const str = new TextDecoder().decode(bytes);
+  assert.match(str, /"createdAt":100,/);
+});
+
+// ---------------------------------------------------------------------------
+// signWorkspaceAttestation / verifyWorkspaceAttestation
+// ---------------------------------------------------------------------------
+
+test('workspace attestation: sign + verify round-trip', () => {
+  const root = keypair();
+  const att = signWorkspaceAttestation(
+    { workspaceId: 'wid-1', createdAt: 1717200000, formatVersion: 1 },
+    root.secretKey,
+  );
+  assert.equal(verifyWorkspaceAttestation(att), true);
+});
+
+test('workspace attestation: rootDid matches what didFromSeed would produce', () => {
+  // The seed is the first 32 bytes of the sodium secret key.
+  const root = keypair();
+  const seed = root.secretKey.subarray(0, 32);
+  const expectedDid = didFromSeed(seed);
+  const att = signWorkspaceAttestation(
+    { workspaceId: 'wid-1', createdAt: 1717200000, formatVersion: 1 },
+    root.secretKey,
+  );
+  assert.equal(att.rootDid, expectedDid);
+});
+
+test('workspace attestation: tampered workspaceId rejects', () => {
+  const root = keypair();
+  const att = signWorkspaceAttestation(
+    { workspaceId: 'wid-1', createdAt: 1717200000, formatVersion: 1 },
+    root.secretKey,
+  );
+  const tampered = {
+    ...att,
+    payload: { ...att.payload, workspaceId: 'wid-evil' },
+  };
+  assert.equal(verifyWorkspaceAttestation(tampered), false);
+});
+
+test('workspace attestation: tampered createdAt rejects', () => {
+  const root = keypair();
+  const att = signWorkspaceAttestation(
+    { workspaceId: 'wid-1', createdAt: 1717200000, formatVersion: 1 },
+    root.secretKey,
+  );
+  const tampered = { ...att, payload: { ...att.payload, createdAt: 9999999999 } };
+  assert.equal(verifyWorkspaceAttestation(tampered), false);
+});
+
+test('workspace attestation: tampered signature rejects', () => {
+  const root = keypair();
+  const att = signWorkspaceAttestation(
+    { workspaceId: 'wid-1', createdAt: 1717200000, formatVersion: 1 },
+    root.secretKey,
+  );
+  const sig = new Uint8Array(att.signature);
+  sig[0] = sig[0]! ^ 0x01;
+  assert.equal(verifyWorkspaceAttestation({ ...att, signature: sig }), false);
+});
+
+test('workspace attestation: claiming a different rootDid rejects', () => {
+  const root = keypair();
+  const imposter = keypair();
+  const imposterDid = didFromSeed(imposter.secretKey.subarray(0, 32));
+  const att = signWorkspaceAttestation(
+    { workspaceId: 'wid-1', createdAt: 1717200000, formatVersion: 1 },
+    root.secretKey,
+  );
+  assert.equal(
+    verifyWorkspaceAttestation({ ...att, rootDid: imposterDid }),
+    false,
+  );
+});
+
+test('workspace attestation: tampered payloadBytes (mismatched against payload) rejects', () => {
+  const root = keypair();
+  const att = signWorkspaceAttestation(
+    { workspaceId: 'wid-1', createdAt: 1717200000, formatVersion: 1 },
+    root.secretKey,
+  );
+  // Build a different payload's bytes and slip them in.
+  const otherBytes = buildAttestationPayload({
+    workspaceId: 'wid-other',
+    createdAt: 1717200000,
+    formatVersion: 1,
+  });
+  assert.equal(
+    verifyWorkspaceAttestation({ ...att, payloadBytes: otherBytes }),
+    false,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// did.ts additions: publicKeyFromDid is the inverse of didFromSeed
+// ---------------------------------------------------------------------------
+
+test('publicKeyFromDid: returns the same bytes that produced the DID', () => {
+  const seed = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) seed[i] = i;
+  const kp = hypercoreCrypto.keyPair(Buffer.from(seed)) as { publicKey: Buffer };
+  const did = didFromSeed(seed);
+  const recovered = publicKeyFromDid(did);
+  assert.deepEqual(Array.from(recovered), Array.from(new Uint8Array(kp.publicKey)));
+});
+
+test('publicKeyFromDid: rejects non-did:key strings', () => {
+  assert.throws(() => publicKeyFromDid('did:web:example.com' as `did:key:${string}`), /did:key:z…/);
+});


### PR DESCRIPTION
## Summary

Adds the cryptographic primitive that lets a `.workspace` bundle prove its identity hasn't been tampered with and isn't a stale replay.

The root DID signs over a canonical payload of `(workspaceId, createdAt, formatVersion)`. Verifiers re-derive the payload bytes, decode the root DID to an ed25519 public key, and check the signature.

## What this defends against

- Post-distribution tampering of the manifest
- Replay of stale workspaces (resurrecting a deleted org's bundle)

## What this does NOT defend against

- **Fraudulent identity claims.** Verifying that a given `did:key:zABC…` genuinely belongs to "Acme's org root" still requires an out-of-band channel (signed announcement, well-known URL, fingerprint comparison). Spelled out in [`docs/threat-model.md`](https://github.com/workspace-sh/workspace-p2p-spike/blob/docs/threat-model-and-workspace-format/docs/threat-model.md) (PR #14).

## Surface

In `packages/p2p-runtime/src/attestation.ts` (new file):

| Function | Purpose |
|---|---|
| `sign(msg, secretKey)` / `verify(msg, sig, pubKey)` | Low-level ed25519 over arbitrary bytes |
| `buildAttestationPayload({workspaceId, createdAt, formatVersion})` | Canonical bytes — deterministic, alphabetical key order |
| `signWorkspaceAttestation(payload, rootSecretKey)` | Full `SignedAttestation` ready to persist as `_workspace/attestation.json`. `rootDid` is derived automatically |
| `verifyWorkspaceAttestation(att)` | Re-derives bytes, decodes rootDid to pubkey, checks signature. Returns `false` on any mismatch |

In `packages/p2p-runtime/src/did.ts` (additions):

| Function | Purpose |
|---|---|
| `didFromPublicKey(pubKey)` | Extracted helper from existing `didFromSeed` for callers with a pubkey in hand |
| `publicKeyFromDid(did)` | Inverse of `didFromPublicKey` — needed for attestation verification, also useful for wrap.ts callers who only have a DID |
| `base58btcDecode` | Sibling of the existing encoder |

## Tests — 20 new, 35 total green

```
ℹ tests 35
ℹ pass 35
ℹ fail 0
```

**Low-level sign/verify** (7 tests): round-trip, wrong-key rejects, tampered-message rejects, tampered-signature rejects, input length validation ×3.

**Canonical payload** (4 tests): determinism, field-order insensitivity, exact alphabetical key order asserted on the output string, createdAt floored to whole seconds.

**Workspace attestation** (7 tests): sign+verify round-trip, rootDid derivation matches `didFromSeed`, tampered workspaceId / createdAt / signature / rootDid all reject, tampered payloadBytes mismatched against payload rejects (defence-in-depth — catches the inconsistency before relying on signature failure).

**did.ts inverse** (2 tests): `publicKeyFromDid` round-trip; rejects non-`did:key:z…` strings.

## Implementation notes

- Signature lineage is ed25519 via `hypercore-crypto` — same algorithm as ucanto's `@noble/ed25519`. Signatures produced by this module can be verified by ucan-boundary's signer (and vice versa) if cross-package interop is ever needed.
- Canonical-payload encoding is "explicit alphabetical key order, no whitespace, UTF-8 JSON." Sufficient because the payload shape is fixed; if the payload ever grows nested or open-ended, switch to a proper canonical-JSON or CBOR encoding.
- The `verifyWorkspaceAttestation` function deliberately re-derives `payloadBytes` from `att.payload` and checks the result matches what's stored, before doing the signature check. This catches mismatches early with a clearer outcome (rather than relying on signature failure to surface the same inconsistency).

## Pre-existing, out of scope

The same 4 typecheck errors PR #13 already noted (`react-native` module-not-found, `MacOSRuntimeOptions` re-export collision). Unchanged by this PR.

## Relation to other open PRs

- **PR #13 (wrap primitive)** — independent. Both this and #13 add files to `p2p-runtime` but to different paths. Either order.
- **PR #14 (docs)** — references this work; the threat-model framing of "what root attestation does and doesn't do" is captured there. Either order.
- **PR #20 (ucan-boundary)** — independent. Both this and #20 use ed25519 (via different implementations: `hypercore-crypto` vs `@noble/ed25519`). Signatures interop.

## Sets up

- [#15 portable bootstrap envelopes](https://github.com/workspace-sh/workspace-p2p-spike/issues/15) — depends on this primitive to verify the manifest before trusting it.

## Issue

Closes #16. Sub-issue of #5.

## Test plan

- [x] `npm test --workspace=packages/p2p-runtime` — 35/35
- [x] `npm run typecheck --workspace=packages/p2p-runtime` — no new errors beyond the 4 pre-existing

🤖 Generated with [Claude Code](https://claude.com/claude-code)