### PR TITLE
docs: resolve the store location — dual form, ratified

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -120,7 +120,7 @@ Project board: https://github.com/orgs/workspace-sh/projects/6
 ## Open questions (not blockers)
 
 - **Node binary on macOS** — development uses the system `node`; a production RN-macOS app needs a bundled static binary or an assumption that Node is present. Either is tractable.
-- **Corestore persistence** — `:memory:` is a temp directory under the hood. Production storage path needs to be wired to the app's sandbox container.
+- ~~**Corestore persistence**~~ — **resolved** ([ADR 0003](./docs/adr/0003-store-dual-form.md)): the store has two forms. The RocksDB working store lives in app-private storage (macOS Application Support; mobile app containers); `.workspace/store/` carries an append-only serialised transport form, flushed on close/share and hydrated on open. Normative detail in [`workspace-format.md`](./docs/workspace-format.md) § `store/`; app-side implementation tracked in workspace#249.
 
 ---
 

--- a/docs/adr/0003-store-dual-form.md
+++ b/docs/adr/0003-store-dual-form.md
@@ -1,0 +1,95 @@
+# ADR 0003 — The store has two forms: RocksDB working copy, serialised transport copy
+
+**Status:** Accepted · **Date:** 2026-08 · **Tracks:** [#32](https://github.com/workspace-sh/workspace-p2p-spike/issues/32), [workspace#249](https://github.com/workspace-sh/workspace/issues/249)
+
+## Context
+
+`workspace-format.md` places the encrypted store inside the folder
+(`.workspace/store/`) in five places, and invariant 4 asserts the
+metadata layout is append-only and content-addressed, "so there are
+none" of the mutable lock/state files that break under cloud sync.
+
+Meanwhile `FINDINGS.md` carried, under *Open questions*: "production
+storage path needs to be wired to the app's sandbox container" — the
+opposite location. The app implementation followed FINDINGS; the
+format doc was never reconciled. Neither document decided anything:
+the question was parked, then hardened into behaviour by being
+implemented.
+
+Two facts surfaced when the contradiction was finally forced
+(workspace#249):
+
+1. **Corestore v7 is RocksDB-backed.** RocksDB was never chosen — it
+   arrived transitively when Corestore v6's file-per-core storage
+   became v7's RocksDB. An LSM store ships `LOCK`, `CURRENT`,
+   `MANIFEST-*`, `OPTIONS-*`, and compaction that rewrites and
+   deletes files: precisely what invariant 4 says does not exist.
+   The invariant was true of Hypercore the *data structure* and
+   false of its storage engine.
+2. **With the store outside the folder, a created `.workspace` was an
+   8 KB bootstrap stub.** A `cp -R` produced a manifest pointing at
+   data the recipient does not have — breaking invariants 1 and 5 and
+   every portability claim (USB stick, AirDrop, heavy bundle) the
+   format leads with.
+
+The app-side code justified the outside location by citing invariant
+4 as a prohibition ("corestore must never live there"). It is not
+one; it is a tolerance requirement on what *is* in the folder. The
+conclusion happened to be right for the unnamed RocksDB reason.
+
+## Options considered
+
+1. **Store inside the folder as-is; soften invariant 4.** Accept
+   RocksDB's files, demote "survives cloud sync" to best-effort.
+   Cheapest; quietly retires the portability promise for any
+   cloud-synced folder, which is where real users keep folders.
+2. **Dual form.** Working store (RocksDB) in app-private storage;
+   `.workspace/store/` carries an append-only, content-addressed
+   serialisation of the signed blocks, flushed on close/share and
+   hydrated on open. Every invariant holds as written.
+3. **Replace the storage backend** with something genuinely
+   append-only on disk. Largest change; argues with the Holepunch
+   ecosystem instead of using it; re-runs the risk the spike existed
+   to retire.
+
+## Decision
+
+**Option 2.** A Hypercore log is already a sequence of signed blocks,
+so serialising it is the natural operation, not a workaround. The
+"unpack on open, operate on the folder" model is one the format
+already commits to for archives (invariant 3); this applies the same
+shape to the store. The engine stays an implementation detail; the
+folder stays the artefact.
+
+The normative description — layout, atomic-write rule, lifecycle,
+valid-but-stale copy semantics, per-platform working-store locations —
+lives in [`../workspace-format.md`](../workspace-format.md) under
+`store/`. This ADR is the why; that doc is the how.
+
+## Consequences
+
+- The portability promises become implementable: flush-then-copy
+  yields a self-contained folder, including ciphertext for tiers the
+  copier cannot read.
+- An explicit flush step exists. Close and share must flush; a crash
+  before flush loses nothing from the working store but leaves the
+  folder stale until the next flush or sync.
+- Hydration must verify blocks offline against the log's public key.
+  The exact Hypercore proof API for block-plus-proof export/import is
+  an implementation question — timeboxed task in the workspace#249
+  plan, with the block-file format versioned (`store/v1/`) so a
+  change of proof encoding is a new version, not a breakage.
+- The working store is declared a rebuildable cache. Backup guidance
+  points at the folder, never at Application Support.
+- Append-only means the store only grows. GC/compaction of the
+  transport form (and of Hypercore history generally) is explicitly
+  out of scope here and joins the existing store-size questions.
+
+## Revisit triggers
+
+- Corestore moves off RocksDB, or gains a portable single-file
+  export of its own.
+- Autobase multi-writer (#11) multiplies per-peer logs enough that
+  one-file-per-block stops being tenable on real filesystems.
+- Partial/sparse workspace sync becomes a requirement (huge
+  workspaces where hydrating everything on open is unacceptable).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,3 +13,4 @@ ADR is just the decision.
 |---|---|---|
 | [0001](./0001-ucan-library.md) | UCAN library: ucanto (not iso-ucan) | Accepted |
 | [0002](./0002-autobase-merge-strategy.md) | Multi-writer merge: per-format LWW over Autobase | Accepted (design) |
+| [0003](./0003-store-dual-form.md) | Store: RocksDB working copy + serialised transport copy in `.workspace/store/` | Accepted |

--- a/docs/workspace-format.md
+++ b/docs/workspace-format.md
@@ -135,7 +135,7 @@ my-org.workspace/                      ← the workspace itself
     ├── policy.json                    ← workspace's cleanup/rotation policy
     ├── envelopes/                     ← bootstrap envelopes for invited peers
     ├── keys/                          ← this peer's local key state
-    └── store/                         ← encrypted Hypercore blocks
+    └── store/                         ← logs in transport form (see `store/`)
 ```
 
 Everything *above* `.workspace/` is the user-facing working tree:
@@ -566,11 +566,75 @@ does because the general version was read past once already.
 
 ### `store/`
 
-The Hypercore corestore. Encrypted append-only blocks for the
-workspace's data log and key-delivery log. Opaque to anyone
-inspecting the directory by hand. The Workspace app projects
+The workspace's logs in **transport form**: an append-only,
+content-addressed serialisation of every Hypercore block, which is
+what makes the folder a complete, portable copy of the workspace.
+Opaque to anyone inspecting it by hand. The Workspace app projects
 relevant blocks into the working tree (for public-tier content) or
 into in-memory views (for tier-gated content).
+
+Layout (store format v1):
+
+```
+store/
+└── v1/
+    └── <log-key-hex>/
+        ├── 0
+        ├── 1
+        └── …                ← one file per block
+```
+
+- Each file holds one block exactly as it exists in the log —
+  **ciphertext** under the relevant tier key — together with the
+  Merkle proof that lets any peer verify it against the log's public
+  key, offline, with no other party present.
+- Committed files are never rewritten, renamed, or deleted. There are
+  no locks, no manifests, no counters: the set of files *is* the
+  state, and a log's length is the highest contiguous index present.
+  This is the property invariant 4 requires, satisfied by
+  construction rather than by discipline.
+- Writers create each file atomically (write to a temp name inside
+  `store/`, fsync, rename into place). Readers ignore any name that
+  is not a bare block index, which also makes them immune to sync
+  engines' conflicted-copy siblings.
+
+### The store has two forms — only one lives in the folder
+
+The live store the app operates on — the **working store** — is a
+Corestore, and Corestore v7 persists through RocksDB: fast, mutable,
+and full of exactly the lock and manifest files (`LOCK`, `CURRENT`,
+`MANIFEST-*`) that invariant 4 forbids from ever meeting a cloud-sync
+engine. It therefore lives in app-private storage, outside the
+folder, and is **not part of this format**:
+
+| Platform | Working store location |
+|---|---|
+| macOS | `~/Library/Application Support/<bundle id>/p2p/store` |
+| iOS / Android | app container documents directory, under `/p2p` |
+
+The working store is a rebuildable cache: the union of every
+transport form it has hydrated plus writes not yet flushed. Losing it
+loses nothing that has been flushed or replicated.
+
+Lifecycle between the two forms:
+
+```
+open    → hydrate: ingest transport blocks the working store lacks,
+          verifying each against its log's public key
+edit    → append to the working store; replicate to peers as normal
+close   → flush: write blocks the transport form lacks
+share   → flush, then the folder is copied by any ordinary means
+```
+
+Copying the folder mid-write yields a workspace that is **valid but
+possibly stale**: every complete block file verifies, the newest
+blocks may be absent, and staleness heals through ordinary
+replication when the copy next syncs. A torn block file fails
+verification and is ignored, then re-fetched. This is the same
+recency model as copying any file while its author is still typing.
+
+Rationale, options considered, and the history that led here:
+[`adr/0003-store-dual-form.md`](./adr/0003-store-dual-form.md).
 
 ---
 


### PR DESCRIPTION
Closes #32.

The gap: `workspace-format.md` put the store inside the folder (five places); `FINDINGS.md` parked the opposite under *Open questions*; the implementation followed FINDINGS and the spec was never reconciled. Result downstream: a created `.workspace` folder was an 8 KB stub (workspace#249).

**Resolution — the store has two forms:**

- **Working store** (RocksDB, mutable, lock files): app-private storage per platform. A rebuildable cache, not part of the format.
- **Transport form** (`.workspace/store/`): append-only, content-addressed serialisation — one file per block, ciphertext + Merkle proof, atomic writes, committed files never mutated. Flushed on close/share, hydrated on open. Mid-write copies are valid-but-stale and heal via replication.

Every invariant holds as written — invariant 4 is satisfied by construction, invariants 1/5 and the heavy-bundle shape become implementable.

**Signal/noise split, per the ask:** `workspace-format.md` carries only the normative *how*. The history — the two-doc contradiction, RocksDB arriving transitively with Corestore v7, the misquoted invariant — lives in **ADR 0003**, following the repo's existing ADR convention. FINDINGS' open question is struck with pointers to both.

App-side implementation plan lands on workspace#249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013n11GCmmnMbzEyijrFakGJ