### PR TITLE
docs: how a device holds many workspaces, and what that costs

### DIFF
--- a/docs/many-workspaces.md
+++ b/docs/many-workspaces.md
@@ -1,0 +1,92 @@
+# Many workspaces, one runtime
+
+How a device holds more than one workspace open, and why that costs almost
+nothing.
+
+This is implementation detail that turned out to be design: the cost model
+below is what decides whether workspaces can be live by default, and it is not
+obvious from the outside.
+
+## The shape
+
+One device runs **one runtime**: one Corestore, one Hyperswarm, one identity.
+Every workspace it has open lives inside that runtime.
+
+```
+device
+└── runtime                       one corestore, one swarm, one peer identity
+    ├── workspace A               data log, key-delivery log, blob log
+    ├── workspace B               data log, key-delivery log, blob log
+    └── workspace C               …
+```
+
+A workspace is **not** a process, a connection, or a swarm. It is a set of
+logs, a topic, and a manifest. That is what makes holding several of them
+cheap.
+
+## The cost model
+
+This is the part worth internalising, because it inverts the intuition that
+more workspaces means more connections.
+
+| resource | scales with |
+|---|---|
+| Corestore | **one per device** |
+| Swarm | **one per device** |
+| Peer identity | **one per device** |
+| DHT topic announcement | one per workspace |
+| **Connection** | **one per PEER** — not per workspace |
+| Logs | three per workspace (data, key delivery, blobs) |
+
+The connection row is the important one. `store.replicate(connection)`
+multiplexes **every core the store holds** over a single stream. So if you and
+another person share ten workspaces, you have **one** connection carrying ten
+workspaces' worth of cores — not ten connections.
+
+Adding a workspace therefore costs a topic announcement and some logs. It does
+not cost a connection, a process, or a peer identity.
+
+## What this means
+
+- **Live by default is affordable.** Keeping every known workspace open is
+  proportional to the number of *people* you collaborate with, not the number
+  of workspaces you have.
+- **Opening a workspace is a local operation.** Its logs open from the local
+  store immediately; the topic announcement happens in the background and may
+  never land on a restricted network. See
+  [network-conditions.md](./network-conditions.md) — the announce has been
+  measured at 40 seconds where opening the store takes 73 ms.
+- **A workspace closing is not a process ending.** The runtime outlives any
+  individual workspace and is torn down with the app.
+
+## Consequences for an implementation
+
+Three rules follow, each of which was learned by getting it wrong first.
+
+**The runtime is shared, so nothing that belongs to one workspace may be scoped
+to it.** Request ids on a shared IPC channel are the sharp case: numbering them
+per workspace is correct until two workspaces share a channel, at which point
+each resolves on the other's replies — silently, with the wrong data. Ids must
+be unique across the runtime, not within a workspace.
+
+**A workspace's own state stays with the workspace.** Its folded documents, its
+watcher, its reconcile latch. A single "active workspace" holding any of these
+means opening a second one evicts the first — a constraint invented by the
+implementation, not by the format.
+
+**Which workspace owns a path is decided by the deepest containing folder.** A
+workspace nested inside another owns its own documents; the enclosing folder
+does not claim them. Containment compares against the folder plus a path
+separator, or `/a/Docs` contains `/a/Docs-old/note.md` and a file in an
+unrelated folder is claimed by a workspace that never held it.
+
+## What is deliberately not decided here
+
+- **Whether known workspaces open automatically.** Affordable is not the same
+  as wanted: opening announces on the DHT, which is a choice about visibility
+  and about someone's data allowance, not only about cost.
+- **Per-workspace network policy.** Whether an individual workspace can be held
+  local-only while others sync. The cost model permits it; nothing specifies
+  it yet.
+
+Refs: workspace#314, workspace#332, workspace#333

--- a/docs/workspace-format.md
+++ b/docs/workspace-format.md
@@ -385,6 +385,18 @@ Designed; implementation pending. Tracked alongside the rest of
 the working-tree work in
 [#24](https://github.com/workspace-sh/workspace-p2p-spike/issues/24).
 
+### A note on holding several
+
+One device runs one runtime — one corestore, one swarm, one
+identity — and every workspace it has open lives inside it. A
+connection is per PEER rather than per workspace, because
+Corestore multiplexes every core it holds over one stream, so
+sharing ten workspaces with someone costs one connection and not
+ten.
+
+See [many-workspaces.md](./many-workspaces.md) for the cost model
+and the three rules an implementation has to follow.
+
 ### A note on the network
 
 Nothing above waits on a peer. That is deliberate and it is


### PR DESCRIPTION
Implementation detail that turned out to be design. The cost model is what decides whether workspaces can be live by default, and it isn't obvious from the outside.

## The finding

One device runs **one runtime** — one Corestore, one Hyperswarm, one identity — and every open workspace lives inside it.

| resource | scales with |
|---|---|
| Corestore / swarm / identity | **one per device** |
| DHT topic announcement | one per workspace |
| **Connection** | **one per PEER — not per workspace** |
| Logs | three per workspace |

`store.replicate(connection)` multiplexes **every core the store holds** over one stream. Sharing ten workspaces with someone costs **one** connection, not ten.

That inverts the intuition that more workspaces means more connections — which is exactly the intuition that produced a one-workspace-at-a-time implementation in the app.

## Three rules, each learned by getting it wrong

- **Nothing belonging to one workspace may be scoped to it when the runtime is shared.** Request ids on a shared IPC channel are the sharp case: per-workspace numbering is correct until two share a channel, at which point each resolves on the other's replies — silently, with the wrong data.
- **A workspace's own state stays with the workspace** — its fold, its watcher, its reconcile latch. A single "active workspace" holding any of these means opening a second evicts the first, a constraint the format never asked for.
- **Ownership of a path is the deepest containing folder**, compared with a separator — or `/a/Docs` contains `/a/Docs-old/note.md`.

## Deliberately not decided

- Whether known workspaces open **automatically**. Affordable is not the same as wanted: announcing is a choice about visibility and about someone's data allowance, not only about cost.
- Whether an individual workspace can be held **local-only** while others sync. The cost model permits it; nothing specifies it.

`workspace-format.md` gains a short pointer next to the network note.

Refs: workspace#314, workspace#332, workspace#333