### PR TITLE
docs(identity): identity storage must survive repackaging the app

### DIFF
--- a/docs/identity-recovery.md
+++ b/docs/identity-recovery.md
@@ -8,6 +8,10 @@ already ship in this repo, not as abstractions.
 remains is orchestration + the pairing-channel and recovery UX. Tracked
 in [#17](https://github.com/workspace-sh/workspace-p2p-spike/issues/17).
 
+The durability requirement below is not design — it is a rule learned
+from an implementation that broke, and it is normative
+([#38](https://github.com/workspace-sh/workspace-p2p-spike/issues/38)).
+
 Primitives in play:
 
 - **Wrapped keys** — X25519 seal to a recipient's key
@@ -25,6 +29,61 @@ Primitives in play:
 
 A device's identity is an ed25519 keypair whose public half is its
 `did:key`; the private half never leaves the device.
+
+### Where that private half lives — a durability requirement
+
+"Never leaves the device" is a confidentiality property. It says nothing
+about whether the key is still *there* tomorrow, and that turns out to be
+the harder half.
+
+**Identity storage must survive repackaging of the app that created it.**
+An identity that disappears when an app is renamed, re-signed, or shipped
+under a new identifier is not a device identity — it is an installation
+identity, and the protocol is entitled to assume otherwise.
+
+This is not hypothetical. It happened during Workspace implementation
+(workspace-sh/workspace#345): the macOS bundle identifier changed, the
+Keychain item became unreadable to the renamed app, and the device minted
+a fresh seed. New seed → new `did:key` → no envelope in any workspace was
+addressed to it any more. The folders were untouched and complete; the
+device had simply become a stranger to them.
+
+Per platform, the trap is the same shape:
+
+- **Apple** — a Keychain item belongs to the *signing app*. Surviving a
+  bundle-identifier change requires a `keychain-access-groups` entitlement
+  with a group scoped to the team rather than the app.
+- **Android** — Keystore aliases are scoped to the package name; a package
+  rename loses them identically.
+- **Anywhere** — storage keyed on an application identifier inherits that
+  identifier's lifetime. Application Support paths built from a bundle id
+  have exactly this problem, and that one is self-inflicted: the path is
+  the implementation's choice, not the platform's.
+
+### Failing to find an identity is not the same as not having one
+
+A renamed app does not get an *error* from the keystore. It gets
+"not found" — byte-for-byte what a genuine first run gets. An
+implementation that mints on "not found" will silently re-identify a
+device that was already a member of things.
+
+**Implementations MUST distinguish the two.** A durable marker outside the
+keystore — recording that an identity was established, in storage that
+does not move — makes the difference observable. Marker present and
+keystore empty is identity *loss*: refuse to mint, and say so. Only the
+absence of both licenses a new identity.
+
+Refusing is not merely tidier. Minting produces a device that appears to
+work, syncs nothing, and gives no indication why — the failure is silent
+at every layer, which is the worst property a failure can have.
+
+### What recovery then means
+
+A device in this state is not broken and neither is the workspace. It is
+an *unlinked device holding a folder*, which §1 already covers: it needs
+an envelope sealed to its new DID. The remedy is an invitation, not a
+repair — and an implementation that has detected the loss can say exactly
+that.
 
 ---
 

--- a/docs/network-conditions.md
+++ b/docs/network-conditions.md
@@ -97,6 +97,90 @@ Piggybacking Holepunch's infrastructure is the right default until measurement
 says it is insufficient. Our own becomes justified when we can point at a row
 in the table above that relaying does not fix.
 
+## Sharing the link — what we cost everything else
+
+Every row above measures what the network costs us. On a constrained link the
+more important number is the reverse: **what we cost every other application
+sharing it.**
+
+Observed during development, on a phone hotspot (`172.20.10.x`), while a
+workspace was open and syncing normally:
+
+- `git push` to github.com over HTTPS reset repeatedly.
+- `api.github.com` worked, then intermittently did not.
+- SSH to the same host worked throughout, uninterrupted.
+- Quitting the app restored the rest.
+
+That pattern is not filtering — filtering does not spare one protocol to the
+same host and then change its mind. It is the signature of **NAT table
+exhaustion**. A phone hotspot keeps a small translation table; the DHT plus
+hole-punching opens many short-lived UDP flows and evicts other applications'
+entries. SSH survived because it was one long-lived connection already
+established and refreshed.
+
+**Confirmed by stopping the app.** With a workspace open, `https://github.com`
+reset on every attempt for roughly an hour. With the app and its Metro process
+quit and nothing else changed:
+
+| probe | app running | app stopped |
+|---|---|---|
+| `https://github.com` | reset, every attempt | HTTP 200 in 0.39–0.44 s, three for three |
+| git `…/info/refs` | reset | HTTP 401 — a completed round trip |
+| GitHub API | reset intermittently | working |
+
+Flow count and table pressure during a join are **still unmeasured**, and
+should get a row of their own on a hotspot and on a home router. What is
+established is the causal direction, not the mechanism's numbers.
+
+### The rule this implies
+
+**A peer-to-peer app on a shared constrained link has an obligation to the
+other traffic on it.** Being local-first is not sufficient: an app that never
+blocks *its own* edits on the network, while making someone's video call
+unusable, has still failed the user. Bandwidth is not the scarce resource here
+— NAT table entries are, and they are shared with everything else the user is
+doing.
+
+This is the argument for connection *modes* rather than a single behaviour
+tuned for a good link.
+
+## Connection modes
+
+Three, distinguished by what the link can afford rather than by what it is:
+
+| mode | swarm behaviour | when |
+|---|---|---|
+| **Unrestricted** | Hyperswarm defaults. Announce, hole-punch, accept connections freely. | Ethernet, home Wi-Fi |
+| **Constrained** | Cap concurrent connections hard. Back off announces. Prefer existing connections over discovering new peers. Do not accept inbound. | Cellular, tethering, hotspot, Low Data Mode, and any link the user has flagged |
+| **Local-only** | No swarm at all. Logs open, edits work, nothing announces. | Offline, or the user's explicit choice |
+
+Two things make this tractable rather than theoretical:
+
+**The platform will tell us.** Apple's `NWPathMonitor` reports `isExpensive`
+(cellular or tethered) and `isConstrained` (Low Data Mode), and Android has
+equivalents in `ConnectivityManager`. Neither is a format concern — it is a
+per-platform input to a decision the runtime makes — but the *modes* should be
+specified here so every platform reaches the same behaviour.
+
+**Local-only must already work.** The rules above require that a workspace is
+readable and writable before any join is attempted, so local-only is not a
+degraded mode needing new code — it is the existing startup path with the join
+skipped. If that is not true, it is a bug in the app rather than a feature to
+build here.
+
+### What is still open
+
+- **Where the mode is decided.** The runtime, from a platform signal, or the
+  app, from a user setting? A user who says "this link is constrained" must be
+  able to override a platform that says otherwise — tethering is not always
+  reported as expensive.
+- **Whether constrained mode is enough.** If a capped swarm still exhausts a
+  hotspot's table, the honest answer is that local-only is the correct default
+  on such links, with syncing an explicit act.
+- **Whether the user is told.** Rule 3 above already asks the app to say which
+  state it is in. "Not syncing, because this connection is metered" is a
+  different sentence from "connecting", and only one of them is actionable.
+
 ## Adding a row
 
 ```ts

--- a/docs/network-conditions.md
+++ b/docs/network-conditions.md
@@ -235,6 +235,87 @@ build here.
   state it is in. "Not syncing, because this connection is metered" is a
   different sentence from "connecting", and only one of them is actionable.
 
+## A flow budget that adapts
+
+The design that follows from the gap above. Not implemented in this repo — this
+is the specification; the app implements it.
+
+### The idea
+
+Congestion control regulates how fast one stream sends. The equivalent for flow
+count is a **budget**: an upper bound on concurrent flows, adjusted by whether
+our own requests are succeeding.
+
+The insight that makes it work: **a NAT table that is full rejects new mappings,
+and the app filling it is the first to notice**, because its own new flows start
+failing. So the harm we do to others has a signature we can see in our own
+numbers — the same trick LEDBAT plays with delay, one layer up.
+
+### The signal
+
+Everything needed is already computed by `dht-rpc` and Hyperswarm:
+
+```
+dht.stats.requests = { active, total, responses, timeouts, retries }
+swarm._allConnections.size   // flows held
+swarm.connecting             // flows in flight
+```
+
+Nobody has wired them into an admission decision. `dht-rpc` uses its own numbers
+only to yield to its own queries.
+
+### The rule
+
+AIMD — additive increase, multiplicative decrease — applied to flow admission
+rather than send rate. The shape is borrowed deliberately: it is well understood,
+it is stable, and it fails towards being quiet.
+
+- **Healthy** (failure rate below the low-water mark): budget grows by one per
+  interval. Slowly, because the cost of being wrong upwards is someone else's
+  connection.
+- **Stressed** (failure rate above the high-water mark **and** flows near the
+  budget): budget halves. Quickly, because the damage is already happening.
+- The second condition matters. A high failure rate while we hold two flows is a
+  bad network, not us. Halving would be superstition.
+
+### Where the environment comes in
+
+The environmental signal — expensive link, hotspot-sized subnet — sets the
+**starting budget and the ceiling**, not the behaviour. It is a prior, not a
+verdict:
+
+| link | start | ceiling |
+|---|---|---|
+| Unrestricted | Hyperswarm default | Hyperswarm default |
+| Expensive or hotspot-shaped | small | modest |
+| No link | zero | zero |
+
+This is the right division of labour. The environment is knowable instantly and
+imprecisely; the pressure is knowable accurately but only after acting. Starting
+careful on a hotspot avoids the first burst doing the damage, and adaptation
+handles everything the heuristic gets wrong — including a hotspot that turns out
+to cope fine, which will simply grow its budget.
+
+### Why not just cap statically
+
+A static cap is a guess that is wrong on both sides: too low on a link that
+could take more, too high on one that cannot. It also cannot notice that
+conditions changed — a hotspot with one other device on it is a different
+proposition from one with six.
+
+### Honest limits
+
+- **We cannot attribute the pressure.** A failure rate that climbs because a
+  video call started looks identical to one we caused. The response is the same
+  either way — open fewer flows — so this is tolerable, but it is not
+  measurement.
+- **A floor is required.** Below some budget the workspace cannot sync at all,
+  and silently reaching that state is worse than syncing slowly. The floor
+  should be "can reach one peer", and hitting it is worth reporting.
+- **It is unverified.** The mechanism is inferred from one reproduction. The
+  measurement that would confirm it — flow counts during a join, on a hotspot
+  and on a home router — is still the outstanding row on this page.
+
 ## Adding a row
 
 ```ts

--- a/docs/network-conditions.md
+++ b/docs/network-conditions.md
@@ -132,6 +132,60 @@ Flow count and table pressure during a join are **still unmeasured**, and
 should get a row of their own on a hotspot and on a home router. What is
 established is the causal direction, not the mechanism's numbers.
 
+### Prior art, and why it does not cover this
+
+Worth knowing what already exists before inventing anything.
+
+**BitTorrent solved the bandwidth version.** µTP with LEDBAT (RFC 6817) is a
+*scavenger* transport: it watches one-way delay and yields the moment anything
+else wants the link. It exists because BitTorrent was making home connections
+unusable — the same complaint, twenty years earlier.
+
+**IPFS/Kubo and libp2p solved the connection-count version.** Watermarked
+connection managers, resource managers with per-scope limits, and a `lowpower`
+profile, all added after nodes overwhelmed routers.
+
+**Neither covers what happened here**, and the reason is worth stating.
+
+Our transport (`libudx`) implements **BBR** — bandwidth and RTT based, with
+explicit pacing. BBR is deliberately *competitive*: it finds the bottleneck and
+takes its share. It is the opposite of a scavenger. But that is beside the
+point, because **congestion control is the wrong axis**. It governs how fast one
+stream sends; the failure here was how many flows exist. A LEDBAT-style
+transport would open exactly the same number of NAT entries and simply push
+fewer bytes through each.
+
+`dht-rpc` does already adapt. It drops background query concurrency from 10 to 2
+when its own requests pile up, under a comment that reads `// yield to other
+traffic`:
+
+```js
+q.on('data', () => {
+  // yield to other traffic
+  q.concurrency = this.io.inflight.length < 3 ? this.concurrency : backgroundCon
+})
+```
+
+**But "other traffic" means its own other queries.** It yields to itself.
+
+### The gap: nothing yields to other applications
+
+There is no mechanism by which a peer-to-peer app defers to *other processes*
+sharing a NAT, because **the signal is not observable from inside the process**.
+LEDBAT works because one-way delay is measurable end to end. There is no
+equivalent measurement for "the router's translation table is nearly full" —
+the kernel does not expose it, the router does not report it, and another
+application's flows are invisible.
+
+This has a consequence for design. An environmental heuristic — *am I behind a
+phone hotspot?* — is not a crude stand-in for a measurement we could take
+properly. **It may be the only signal available.** You cannot observe the table,
+so you infer it from where you are.
+
+That is the argument for detection (below) being load-bearing rather than a
+convenience, and for a user override on top: the person can see things about
+their situation that neither the process nor the platform can.
+
 ### The rule this implies
 
 **A peer-to-peer app on a shared constrained link has an obligation to the

--- a/docs/network-conditions.md
+++ b/docs/network-conditions.md
@@ -128,9 +128,43 @@ quit and nothing else changed:
 | git `…/info/refs` | reset | HTTP 401 — a completed round trip |
 | GitHub API | reset intermittently | working |
 
-Flow count and table pressure during a join are **still unmeasured**, and
-should get a row of their own on a hotspot and on a home router. What is
-established is the causal direction, not the mechanism's numbers.
+### Measured: two sockets, eighty peers
+
+The flow count is no longer unmeasured, and the first attempt at measuring it
+was wrong in a way worth recording.
+
+Counting **sockets** shows nothing. With a workspace open and syncing, the P2P
+child holds **two UDP sockets** — flat over thirty seconds, and total system UDP
+endpoints indistinguishable from baseline. On that evidence the app looks
+entirely innocent, which is what an earlier check concluded.
+
+It is the wrong metric. `udx` multiplexes; it does not open a socket per peer.
+**NAT entries key on the four-tuple**, so two local sockets talking to eighty
+remote endpoints is eighty entries. Capturing on the interface instead:
+
+| metric | value |
+|---|---|
+| local UDP sockets | **2** |
+| distinct remote endpoints (200 packets) | **69**, across 39 IPs |
+| distinct remote endpoints (800 packets) | **80** |
+| **new** endpoints between two nearby samples | **53** |
+
+One peer appeared five times on five different source ports — five entries for
+one relationship.
+
+An iPhone Personal Hotspot hands out a `/28` and keeps a translation table in
+the low hundreds. Fifty-plus new entries in a short window is real pressure
+against that.
+
+**What this establishes, and what it does not.** The mechanism is now measured:
+high endpoint count and high churn from a small socket count. Whether it *causes*
+the observed failures is still correlational — during this capture HTTPS was
+healthy (0.71 s), so the app was applying pressure without anything breaking.
+The earlier incident reproduced once and has not reproduced since.
+
+The honest position: the pressure is real and quantified; the failure threshold
+is not known, and the link is independently unstable enough that a single
+recovery-on-quit should not be read as proof.
 
 ### Prior art, and why it does not cover this
 


### PR DESCRIPTION
Closes the normative half of #38, learned from an implementation that broke rather than from design.

`identity-recovery.md` said a device's private key "never leaves the device" — a confidentiality property that says nothing about whether the key is still there tomorrow. That turned out to be the harder half.

Workspace's macOS bundle identifier changed. A Keychain item belongs to the **signing app**, so the renamed app could not read it, minted a fresh seed, and took a new `did:key`. No envelope in any workspace was addressed to it any more. The folders were untouched and complete; the device had become a stranger to them, silently.

Three normative additions:

**Identity storage must survive repackaging.** An identity that vanishes when an app is renamed or re-signed is an *installation* identity, not a *device* identity. Named per platform — Apple Keychain items belong to the signing app and need a team-scoped `keychain-access-groups`; Android Keystore aliases are scoped to the package name; and any storage path built from an application identifier inherits that identifier's lifetime, which is self-inflicted since the path is the implementation's choice.

**Failing to find an identity is not the same as not having one.** A renamed app gets `errSecItemNotFound` — byte-for-byte what a genuine first run gets. Implementations must tell those apart with a durable marker outside the keystore, refuse to mint when one was lost, and say so. Minting produces a device that appears to work, syncs nothing, and explains nothing, which is the worst property a failure can have.

**What recovery means here.** Such a device is not broken and neither is the workspace: it is an unlinked device holding a folder, which §1 already covers. The remedy is an invitation, not a repair.

Implemented on the app side in workspace-sh/workspace#345 — a constant storage directory, a marker file, and a refusal to mint with a message that explains itself.

Refs: #38