### PR TITLE
sync: bring the packages level with the monorepo, and make the repo typecheck

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -3,8 +3,13 @@
 **Verdict: Go.**
 
 Hypercore is a viable P2P data layer for Workspace across Node, macOS,
-and (by extension) mobile. The permissions, addressing, and discovery
-layers on top are designed and partially implemented.
+iOS, Android and Linux. Mobile is no longer an extrapolation: the Bare
+worklet path runs on device, and the four packages below were extracted
+into the Workspace monorepo and have been developed there since.
+
+This repository is the public reference for the protocol. The code here
+is synced *from* the monorepo, not developed here — a reference that no
+longer matches the implementation is worse than no reference.
 
 ---
 
@@ -124,13 +129,24 @@ Project board: https://github.com/orgs/workspace-sh/projects/6
 
 ---
 
-## Extraction checklist (main monorepo)
+## Extraction: done
 
-1. Copy `packages/p2p-runtime` → Workspace monorepo as `@workspace.sh/p2p-runtime`.
-2. Copy `packages/ucan-boundary` → `@workspace.sh/ucan-boundary`.
-3. Copy `packages/portable-bootstrap` → `@workspace.sh/portable-bootstrap`.
-4. Add `apps/macos/native/P2PRuntimeModule.h` + `.mm` to the macOS Xcode target.
-5. Wire `runtime.macos.ts` export in the package — Metro resolves `.macos.ts` automatically.
-6. Set `childScriptPath` + `nodeBin` in the macOS app bootstrap.
-7. The mobile path is a separate spike — `react-native-bare-kit` replaces the NSTask path on iOS/Android.
-8. Lift the nine design docs into the main monorepo (or keep them in the spike repo with cross-references).
+All four packages live in the Workspace monorepo and are developed there.
+The macOS native module is on the Xcode target, `runtime.macos.ts` is
+wired, and the mobile path is no longer a separate spike —
+`react-native-bare-kit` replaces the NSTask path on iOS and Android, and
+a fourth client (GTK4 on Linux) consumes the same packages.
+
+The design docs stay here, and this is now the direction of travel: the
+monorepo is where the code changes, and this repository is synced from it
+so that the spec and the implementation cannot drift apart silently.
+
+Two divergences are deliberate, and exist so this repo stays clonable and
+runnable with no native toolchain and no app framework:
+
+- `packages/p2p-runtime/src/ambient.react-native.d.ts` declares the two
+  React Native symbols the macOS bridge imports, rather than taking a
+  react-native dependency for two files.
+- The sibling packages' `tsconfig.json` includes are widened to
+  `../p2p-runtime/src/*.d.ts`, so both ambient files are picked up when
+  those packages typecheck p2p-runtime sources.

--- a/docs/identity-recovery.md
+++ b/docs/identity-recovery.md
@@ -8,6 +8,10 @@ already ship in this repo, not as abstractions.
 remains is orchestration + the pairing-channel and recovery UX. Tracked
 in [#17](https://github.com/workspace-sh/workspace-p2p-spike/issues/17).
 
+The durability requirement below is not design — it is a rule learned
+from an implementation that broke, and it is normative
+([#38](https://github.com/workspace-sh/workspace-p2p-spike/issues/38)).
+
 Primitives in play:
 
 - **Wrapped keys** — X25519 seal to a recipient's key
@@ -25,6 +29,61 @@ Primitives in play:
 
 A device's identity is an ed25519 keypair whose public half is its
 `did:key`; the private half never leaves the device.
+
+### Where that private half lives — a durability requirement
+
+"Never leaves the device" is a confidentiality property. It says nothing
+about whether the key is still *there* tomorrow, and that turns out to be
+the harder half.
+
+**Identity storage must survive repackaging of the app that created it.**
+An identity that disappears when an app is renamed, re-signed, or shipped
+under a new identifier is not a device identity — it is an installation
+identity, and the protocol is entitled to assume otherwise.
+
+This is not hypothetical. It happened during Workspace implementation
+(workspace-sh/workspace#345): the macOS bundle identifier changed, the
+Keychain item became unreadable to the renamed app, and the device minted
+a fresh seed. New seed → new `did:key` → no envelope in any workspace was
+addressed to it any more. The folders were untouched and complete; the
+device had simply become a stranger to them.
+
+Per platform, the trap is the same shape:
+
+- **Apple** — a Keychain item belongs to the *signing app*. Surviving a
+  bundle-identifier change requires a `keychain-access-groups` entitlement
+  with a group scoped to the team rather than the app.
+- **Android** — Keystore aliases are scoped to the package name; a package
+  rename loses them identically.
+- **Anywhere** — storage keyed on an application identifier inherits that
+  identifier's lifetime. Application Support paths built from a bundle id
+  have exactly this problem, and that one is self-inflicted: the path is
+  the implementation's choice, not the platform's.
+
+### Failing to find an identity is not the same as not having one
+
+A renamed app does not get an *error* from the keystore. It gets
+"not found" — byte-for-byte what a genuine first run gets. An
+implementation that mints on "not found" will silently re-identify a
+device that was already a member of things.
+
+**Implementations MUST distinguish the two.** A durable marker outside the
+keystore — recording that an identity was established, in storage that
+does not move — makes the difference observable. Marker present and
+keystore empty is identity *loss*: refuse to mint, and say so. Only the
+absence of both licenses a new identity.
+
+Refusing is not merely tidier. Minting produces a device that appears to
+work, syncs nothing, and gives no indication why — the failure is silent
+at every layer, which is the worst property a failure can have.
+
+### What recovery then means
+
+A device in this state is not broken and neither is the workspace. It is
+an *unlinked device holding a folder*, which §1 already covers: it needs
+an envelope sealed to its new DID. The remedy is an invitation, not a
+repair — and an implementation that has detected the loss can say exactly
+that.
 
 ---
 

--- a/docs/network-conditions.md
+++ b/docs/network-conditions.md
@@ -97,6 +97,90 @@ Piggybacking Holepunch's infrastructure is the right default until measurement
 says it is insufficient. Our own becomes justified when we can point at a row
 in the table above that relaying does not fix.
 
+## Sharing the link — what we cost everything else
+
+Every row above measures what the network costs us. On a constrained link the
+more important number is the reverse: **what we cost every other application
+sharing it.**
+
+Observed during development, on a phone hotspot (`172.20.10.x`), while a
+workspace was open and syncing normally:
+
+- `git push` to github.com over HTTPS reset repeatedly.
+- `api.github.com` worked, then intermittently did not.
+- SSH to the same host worked throughout, uninterrupted.
+- Quitting the app restored the rest.
+
+That pattern is not filtering — filtering does not spare one protocol to the
+same host and then change its mind. It is the signature of **NAT table
+exhaustion**. A phone hotspot keeps a small translation table; the DHT plus
+hole-punching opens many short-lived UDP flows and evicts other applications'
+entries. SSH survived because it was one long-lived connection already
+established and refreshed.
+
+**Confirmed by stopping the app.** With a workspace open, `https://github.com`
+reset on every attempt for roughly an hour. With the app and its Metro process
+quit and nothing else changed:
+
+| probe | app running | app stopped |
+|---|---|---|
+| `https://github.com` | reset, every attempt | HTTP 200 in 0.39–0.44 s, three for three |
+| git `…/info/refs` | reset | HTTP 401 — a completed round trip |
+| GitHub API | reset intermittently | working |
+
+Flow count and table pressure during a join are **still unmeasured**, and
+should get a row of their own on a hotspot and on a home router. What is
+established is the causal direction, not the mechanism's numbers.
+
+### The rule this implies
+
+**A peer-to-peer app on a shared constrained link has an obligation to the
+other traffic on it.** Being local-first is not sufficient: an app that never
+blocks *its own* edits on the network, while making someone's video call
+unusable, has still failed the user. Bandwidth is not the scarce resource here
+— NAT table entries are, and they are shared with everything else the user is
+doing.
+
+This is the argument for connection *modes* rather than a single behaviour
+tuned for a good link.
+
+## Connection modes
+
+Three, distinguished by what the link can afford rather than by what it is:
+
+| mode | swarm behaviour | when |
+|---|---|---|
+| **Unrestricted** | Hyperswarm defaults. Announce, hole-punch, accept connections freely. | Ethernet, home Wi-Fi |
+| **Constrained** | Cap concurrent connections hard. Back off announces. Prefer existing connections over discovering new peers. Do not accept inbound. | Cellular, tethering, hotspot, Low Data Mode, and any link the user has flagged |
+| **Local-only** | No swarm at all. Logs open, edits work, nothing announces. | Offline, or the user's explicit choice |
+
+Two things make this tractable rather than theoretical:
+
+**The platform will tell us.** Apple's `NWPathMonitor` reports `isExpensive`
+(cellular or tethered) and `isConstrained` (Low Data Mode), and Android has
+equivalents in `ConnectivityManager`. Neither is a format concern — it is a
+per-platform input to a decision the runtime makes — but the *modes* should be
+specified here so every platform reaches the same behaviour.
+
+**Local-only must already work.** The rules above require that a workspace is
+readable and writable before any join is attempted, so local-only is not a
+degraded mode needing new code — it is the existing startup path with the join
+skipped. If that is not true, it is a bug in the app rather than a feature to
+build here.
+
+### What is still open
+
+- **Where the mode is decided.** The runtime, from a platform signal, or the
+  app, from a user setting? A user who says "this link is constrained" must be
+  able to override a platform that says otherwise — tethering is not always
+  reported as expensive.
+- **Whether constrained mode is enough.** If a capped swarm still exhausts a
+  hotspot's table, the honest answer is that local-only is the correct default
+  on such links, with syncing an explicit act.
+- **Whether the user is told.** Rule 3 above already asks the app to say which
+  state it is in. "Not syncing, because this connection is metered" is a
+  different sentence from "connecting", and only one of them is actionable.
+
 ## Adding a row
 
 ```ts

--- a/docs/network-conditions.md
+++ b/docs/network-conditions.md
@@ -235,6 +235,87 @@ build here.
   state it is in. "Not syncing, because this connection is metered" is a
   different sentence from "connecting", and only one of them is actionable.
 
+## A flow budget that adapts
+
+The design that follows from the gap above. Not implemented in this repo — this
+is the specification; the app implements it.
+
+### The idea
+
+Congestion control regulates how fast one stream sends. The equivalent for flow
+count is a **budget**: an upper bound on concurrent flows, adjusted by whether
+our own requests are succeeding.
+
+The insight that makes it work: **a NAT table that is full rejects new mappings,
+and the app filling it is the first to notice**, because its own new flows start
+failing. So the harm we do to others has a signature we can see in our own
+numbers — the same trick LEDBAT plays with delay, one layer up.
+
+### The signal
+
+Everything needed is already computed by `dht-rpc` and Hyperswarm:
+
+```
+dht.stats.requests = { active, total, responses, timeouts, retries }
+swarm._allConnections.size   // flows held
+swarm.connecting             // flows in flight
+```
+
+Nobody has wired them into an admission decision. `dht-rpc` uses its own numbers
+only to yield to its own queries.
+
+### The rule
+
+AIMD — additive increase, multiplicative decrease — applied to flow admission
+rather than send rate. The shape is borrowed deliberately: it is well understood,
+it is stable, and it fails towards being quiet.
+
+- **Healthy** (failure rate below the low-water mark): budget grows by one per
+  interval. Slowly, because the cost of being wrong upwards is someone else's
+  connection.
+- **Stressed** (failure rate above the high-water mark **and** flows near the
+  budget): budget halves. Quickly, because the damage is already happening.
+- The second condition matters. A high failure rate while we hold two flows is a
+  bad network, not us. Halving would be superstition.
+
+### Where the environment comes in
+
+The environmental signal — expensive link, hotspot-sized subnet — sets the
+**starting budget and the ceiling**, not the behaviour. It is a prior, not a
+verdict:
+
+| link | start | ceiling |
+|---|---|---|
+| Unrestricted | Hyperswarm default | Hyperswarm default |
+| Expensive or hotspot-shaped | small | modest |
+| No link | zero | zero |
+
+This is the right division of labour. The environment is knowable instantly and
+imprecisely; the pressure is knowable accurately but only after acting. Starting
+careful on a hotspot avoids the first burst doing the damage, and adaptation
+handles everything the heuristic gets wrong — including a hotspot that turns out
+to cope fine, which will simply grow its budget.
+
+### Why not just cap statically
+
+A static cap is a guess that is wrong on both sides: too low on a link that
+could take more, too high on one that cannot. It also cannot notice that
+conditions changed — a hotspot with one other device on it is a different
+proposition from one with six.
+
+### Honest limits
+
+- **We cannot attribute the pressure.** A failure rate that climbs because a
+  video call started looks identical to one we caused. The response is the same
+  either way — open fewer flows — so this is tolerable, but it is not
+  measurement.
+- **A floor is required.** Below some budget the workspace cannot sync at all,
+  and silently reaching that state is worse than syncing slowly. The floor
+  should be "can reach one peer", and hitting it is worth reporting.
+- **It is unverified.** The mechanism is inferred from one reproduction. The
+  measurement that would confirm it — flow counts during a join, on a hotspot
+  and on a home router — is still the outstanding row on this page.
+
 ## Adding a row
 
 ```ts

--- a/docs/network-conditions.md
+++ b/docs/network-conditions.md
@@ -132,6 +132,60 @@ Flow count and table pressure during a join are **still unmeasured**, and
 should get a row of their own on a hotspot and on a home router. What is
 established is the causal direction, not the mechanism's numbers.
 
+### Prior art, and why it does not cover this
+
+Worth knowing what already exists before inventing anything.
+
+**BitTorrent solved the bandwidth version.** µTP with LEDBAT (RFC 6817) is a
+*scavenger* transport: it watches one-way delay and yields the moment anything
+else wants the link. It exists because BitTorrent was making home connections
+unusable — the same complaint, twenty years earlier.
+
+**IPFS/Kubo and libp2p solved the connection-count version.** Watermarked
+connection managers, resource managers with per-scope limits, and a `lowpower`
+profile, all added after nodes overwhelmed routers.
+
+**Neither covers what happened here**, and the reason is worth stating.
+
+Our transport (`libudx`) implements **BBR** — bandwidth and RTT based, with
+explicit pacing. BBR is deliberately *competitive*: it finds the bottleneck and
+takes its share. It is the opposite of a scavenger. But that is beside the
+point, because **congestion control is the wrong axis**. It governs how fast one
+stream sends; the failure here was how many flows exist. A LEDBAT-style
+transport would open exactly the same number of NAT entries and simply push
+fewer bytes through each.
+
+`dht-rpc` does already adapt. It drops background query concurrency from 10 to 2
+when its own requests pile up, under a comment that reads `// yield to other
+traffic`:
+
+```js
+q.on('data', () => {
+  // yield to other traffic
+  q.concurrency = this.io.inflight.length < 3 ? this.concurrency : backgroundCon
+})
+```
+
+**But "other traffic" means its own other queries.** It yields to itself.
+
+### The gap: nothing yields to other applications
+
+There is no mechanism by which a peer-to-peer app defers to *other processes*
+sharing a NAT, because **the signal is not observable from inside the process**.
+LEDBAT works because one-way delay is measurable end to end. There is no
+equivalent measurement for "the router's translation table is nearly full" —
+the kernel does not expose it, the router does not report it, and another
+application's flows are invisible.
+
+This has a consequence for design. An environmental heuristic — *am I behind a
+phone hotspot?* — is not a crude stand-in for a measurement we could take
+properly. **It may be the only signal available.** You cannot observe the table,
+so you infer it from where you are.
+
+That is the argument for detection (below) being load-bearing rather than a
+convenience, and for a user override on top: the person can see things about
+their situation that neither the process nor the platform can.
+
 ### The rule this implies
 
 **A peer-to-peer app on a shared constrained link has an obligation to the

--- a/docs/network-conditions.md
+++ b/docs/network-conditions.md
@@ -128,9 +128,43 @@ quit and nothing else changed:
 | git `…/info/refs` | reset | HTTP 401 — a completed round trip |
 | GitHub API | reset intermittently | working |
 
-Flow count and table pressure during a join are **still unmeasured**, and
-should get a row of their own on a hotspot and on a home router. What is
-established is the causal direction, not the mechanism's numbers.
+### Measured: two sockets, eighty peers
+
+The flow count is no longer unmeasured, and the first attempt at measuring it
+was wrong in a way worth recording.
+
+Counting **sockets** shows nothing. With a workspace open and syncing, the P2P
+child holds **two UDP sockets** — flat over thirty seconds, and total system UDP
+endpoints indistinguishable from baseline. On that evidence the app looks
+entirely innocent, which is what an earlier check concluded.
+
+It is the wrong metric. `udx` multiplexes; it does not open a socket per peer.
+**NAT entries key on the four-tuple**, so two local sockets talking to eighty
+remote endpoints is eighty entries. Capturing on the interface instead:
+
+| metric | value |
+|---|---|
+| local UDP sockets | **2** |
+| distinct remote endpoints (200 packets) | **69**, across 39 IPs |
+| distinct remote endpoints (800 packets) | **80** |
+| **new** endpoints between two nearby samples | **53** |
+
+One peer appeared five times on five different source ports — five entries for
+one relationship.
+
+An iPhone Personal Hotspot hands out a `/28` and keeps a translation table in
+the low hundreds. Fifty-plus new entries in a short window is real pressure
+against that.
+
+**What this establishes, and what it does not.** The mechanism is now measured:
+high endpoint count and high churn from a small socket count. Whether it *causes*
+the observed failures is still correlational — during this capture HTTPS was
+healthy (0.71 s), so the app was applying pressure without anything breaking.
+The earlier incident reproduced once and has not reproduced since.
+
+The honest position: the pressure is real and quantified; the failure threshold
+is not known, and the link is independently unstable enough that a single
+recovery-on-quit should not be read as proof.
 
 ### Prior art, and why it does not cover this
 

--- a/packages/p2p-runtime/package.json
+++ b/packages/p2p-runtime/package.json
@@ -19,6 +19,34 @@
     "./spawned": {
       "types": "./src/runtime.spawned.ts",
       "default": "./src/runtime.spawned.ts"
+    },
+    "./ipc": {
+      "types": "./src/ipc/index.ts",
+      "default": "./src/ipc/index.ts"
+    },
+    "./ipc/framing": {
+      "types": "./src/ipc/framing.ts",
+      "default": "./src/ipc/framing.ts"
+    },
+    "./ipc/macos": {
+      "types": "./src/ipc/transport.macos.ts",
+      "default": "./src/ipc/transport.macos.ts"
+    },
+    "./ios": {
+      "types": "./src/runtime.ios.ts",
+      "default": "./src/runtime.ios.ts"
+    },
+    "./android": {
+      "types": "./src/runtime.android.ts",
+      "default": "./src/runtime.android.ts"
+    },
+    "./ipc/ios": {
+      "types": "./src/ipc/transport.ios.ts",
+      "default": "./src/ipc/transport.ios.ts"
+    },
+    "./shims/crypto": {
+      "types": "./src/shims/crypto.ts",
+      "default": "./src/shims/crypto.ts"
     }
   },
   "scripts": {

--- a/packages/p2p-runtime/src/ambient.d.ts
+++ b/packages/p2p-runtime/src/ambient.d.ts
@@ -24,7 +24,9 @@ declare module 'corestore' {
     writable: boolean;
     ready(): Promise<void>;
     close(): Promise<void>;
-    append(block: Uint8Array | Buffer): Promise<number>;
+    // hypercore accepts a single block or a batch; the batch form is what
+    // makes multi-block fixtures cheap to write.
+    append(blocks: Uint8Array | Buffer | Array<Uint8Array | Buffer>): Promise<number>;
     get(index: number, opts?: { wait?: boolean }): Promise<Uint8Array>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     on(event: string, cb: (...args: any[]) => void): this;
@@ -83,4 +85,35 @@ declare module 'compact-encoding' {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const c: { raw: any; [k: string]: any };
   export default c;
+}
+
+// Imported statically (rather than via `createRequire`) so the module graph
+// can be packed for Bare — see #229. `createRequire` had been hiding the
+// absence of types on these two; declaring them is the cost of that fix.
+declare module 'hypercore-crypto' {
+  const hypercoreCrypto: {
+    keyPair(seed?: Uint8Array): { publicKey: Uint8Array; secretKey: Uint8Array };
+    sign(message: Uint8Array, secretKey: Uint8Array): Uint8Array;
+    verify(message: Uint8Array, signature: Uint8Array, publicKey: Uint8Array): boolean;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [k: string]: any;
+  };
+  export default hypercoreCrypto;
+}
+
+declare module 'sodium-universal' {
+  const sodium: {
+    crypto_hash_sha256_BYTES: number;
+    crypto_hash_sha256(out: Uint8Array, input: Uint8Array): void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [k: string]: any;
+  };
+  export default sodium;
+}
+
+// Deep import of hypercore's replication message codecs — the transport form
+// (transport-form.ts) persists and replays wire.data messages verbatim.
+declare module 'hypercore/lib/messages.js' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export const wire: { data: any; [k: string]: any };
 }

--- a/packages/p2p-runtime/src/ambient.react-native.d.ts
+++ b/packages/p2p-runtime/src/ambient.react-native.d.ts
@@ -1,0 +1,26 @@
+// React Native, declared rather than depended on.
+//
+// Two files in this package are the macOS bridge — `ipc/NativeP2PRuntime.ts`
+// and `ipc/transport.macos.ts` — and they import from 'react-native'. In the
+// Workspace monorepo that resolves against the real dependency. Here it must
+// not: this repo is the public reference for the protocol, and it exists to be
+// cloned and run with no native toolchain and no app framework. Taking a
+// react-native dependency to typecheck two files would cost every reader an
+// install they have no use for.
+//
+// So the surface is declared instead, and only the surface actually used. If a
+// third symbol appears here, prefer widening this file over adding the
+// dependency — and if that stops being tenable, the honest fix is to move the
+// bridge out of the reference rather than to install a framework for it.
+
+declare module 'react-native' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export const NativeModules: Record<string, any>;
+
+  export class NativeEventEmitter {
+    constructor(nativeModule?: unknown);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    addListener(event: string, listener: (...args: any[]) => void): {remove(): void};
+    removeAllListeners(event: string): void;
+  }
+}

--- a/packages/p2p-runtime/src/attestation.ts
+++ b/packages/p2p-runtime/src/attestation.ts
@@ -15,14 +15,14 @@
 // used by ucanto's @noble/ed25519. Signatures produced here can be verified
 // by either implementation (and vice versa).
 
-import { createRequire } from 'node:module';
+import b4a from 'b4a';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import hypercoreCryptoModule from 'hypercore-crypto';
 import type { Did } from './types.ts';
 import { didFromPublicKey, publicKeyFromDid } from './did.ts';
 
-const require = createRequire(import.meta.url);
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const hypercoreCrypto = require('hypercore-crypto') as any;
+const hypercoreCrypto = hypercoreCryptoModule as any;
 
 // ---------------------------------------------------------------------------
 // Low-level: sign/verify arbitrary bytes with an ed25519 keypair
@@ -41,7 +41,7 @@ export function sign(message: Uint8Array, secretKey: Uint8Array): Uint8Array {
       `ed25519 secret key must be 64 bytes (sodium format: 32-byte seed + 32-byte pubkey), got ${secretKey.length}`,
     );
   }
-  const sig = hypercoreCrypto.sign(Buffer.from(message), Buffer.from(secretKey)) as Buffer;
+  const sig = hypercoreCrypto.sign(b4a.from(message), b4a.from(secretKey)) as Uint8Array;
   return new Uint8Array(sig);
 }
 
@@ -62,9 +62,9 @@ export function verify(
     throw new Error(`ed25519 signature must be 64 bytes, got ${signature.length}`);
   }
   return hypercoreCrypto.verify(
-    Buffer.from(message),
-    Buffer.from(signature),
-    Buffer.from(publicKey),
+    b4a.from(message),
+    b4a.from(signature),
+    b4a.from(publicKey),
   ) as boolean;
 }
 
@@ -107,7 +107,8 @@ export function buildAttestationPayload(p: AttestationPayload): Uint8Array {
   const canonical = `{"createdAt":${Math.floor(p.createdAt)},"formatVersion":${
     p.formatVersion
   },"workspaceId":${JSON.stringify(p.workspaceId)}}`;
-  return new TextEncoder().encode(canonical);
+  // b4a rather than TextEncoder: Bare has no such global (#243).
+  return b4a.from(canonical);
 }
 
 /**

--- a/packages/p2p-runtime/src/did.ts
+++ b/packages/p2p-runtime/src/did.ts
@@ -13,14 +13,14 @@
 // This replaces the spike placeholder (did:key:z<hex>) with a value that
 // ucanto will accept as a valid DID when building delegation chains.
 
-import { createRequire } from 'node:module';
+import b4a from 'b4a';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import hypercoreCryptoModule from 'hypercore-crypto';
 import type { Did } from './types.ts';
-
-const require = createRequire(import.meta.url);
 
 // hypercore-crypto is a transitive dep of corestore — always present.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const hypercoreCrypto = require('hypercore-crypto') as any;
+const hypercoreCrypto = hypercoreCryptoModule as any;
 
 // ---------------------------------------------------------------------------
 // base58btc — minimal implementation (no external dep needed)
@@ -126,9 +126,9 @@ export function keyPairFromSeed(seed: Uint8Array): {
   if (seed.length !== 32) {
     throw new Error(`seed must be 32 bytes, got ${seed.length}`);
   }
-  const kp = hypercoreCrypto.keyPair(Buffer.from(seed)) as {
-    publicKey: Buffer;
-    secretKey: Buffer;
+  const kp = hypercoreCrypto.keyPair(b4a.from(seed)) as {
+    publicKey: Uint8Array;
+    secretKey: Uint8Array;
   };
   return { publicKey: new Uint8Array(kp.publicKey), secretKey: new Uint8Array(kp.secretKey) };
 }

--- a/packages/p2p-runtime/src/encrypted-log.ts
+++ b/packages/p2p-runtime/src/encrypted-log.ts
@@ -52,6 +52,9 @@ export function encryptedLog(log: Log, key: Uint8Array): Log {
     get length(): number {
       return log.length;
     },
+    get contiguousLength(): number | undefined {
+      return log.contiguousLength;
+    },
     append(block: Uint8Array): Promise<number> {
       return log.append(seal(block, k));
     },

--- a/packages/p2p-runtime/src/hash.ts
+++ b/packages/p2p-runtime/src/hash.ts
@@ -1,0 +1,27 @@
+// Content hashing.
+//
+// Lives beside the other crypto primitives in this package for the reason
+// stated in index.ts — they are independently useful, and consumers should
+// not each reach for their own implementation and drift.
+//
+// sodium rather than `node:crypto`: this package runs under Bare on iOS and
+// Android, where there is no `crypto` builtin. Digests are byte-identical to
+// `createHash('sha256')`.
+
+import b4a from 'b4a';
+import sodiumModule from 'sodium-universal';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sodium = sodiumModule as any;
+
+/** SHA-256 of `input`. */
+export function sha256(input: Uint8Array): Uint8Array {
+  const out = b4a.alloc(sodium.crypto_hash_sha256_BYTES);
+  sodium.crypto_hash_sha256(out, input);
+  return out;
+}
+
+/** SHA-256 of `input`, hex-encoded. */
+export function sha256Hex(input: Uint8Array): string {
+  return b4a.toString(sha256(input), 'hex');
+}

--- a/packages/p2p-runtime/src/index.ts
+++ b/packages/p2p-runtime/src/index.ts
@@ -16,7 +16,10 @@ export type {
 export { didFromSeed, didFromPublicKey, publicKeyFromDid, keyPairFromSeed } from './did.ts';
 export { wrap, unwrap, WRAP_OVERHEAD } from './wrap.ts';
 export { seal, open, SEAL_OVERHEAD, SEAL_KEY_BYTES } from './seal.ts';
+export { sha256, sha256Hex } from './hash.ts';
 export { encryptedLog } from './encrypted-log.ts';
+export { flushLogToDir, hydrateLogFromDir } from './transport-form.ts';
+export type { FlushResult, HydrateResult } from './transport-form.ts';
 export {
   sign,
   verify,

--- a/packages/p2p-runtime/src/ipc/NativeP2PRuntime.ts
+++ b/packages/p2p-runtime/src/ipc/NativeP2PRuntime.ts
@@ -1,7 +1,12 @@
-// React Native TurboModule spec for the macOS P2P runtime bridge.
+// Native module accessor for the macOS P2P runtime bridge.
 //
-// This file is the Codegen input. RN's build system reads it and generates
-// the Obj-C++ protocol that P2PRuntimeModule.mm must implement.
+// This app (workspace-sh/workspace) doesn't use TurboModule Codegen — no
+// `codegenConfig`, no other native module uses `TurboModuleRegistry` — every
+// existing module (FileOpener, SidebarBridge, ScrollWheelBridge,
+// CanvasControlsBridge) is accessed via the classic `NativeModules.<Name>` +
+// `NativeEventEmitter` bridge, matching apps/desktop's own convention (see
+// apps/desktop/src/native/FileOpener.ts). This file follows the same
+// pattern rather than the spike's original TurboModuleRegistry approach.
 //
 // Two events are emitted from native → JS:
 //   'p2pLine'  { line: string }  — one complete stdout line from the child
@@ -10,15 +15,17 @@
 // The native module handles all NSTask lifecycle; JS only calls send() and
 // receives events. No polling, no timers.
 
-import type { TurboModule } from 'react-native';
-import { TurboModuleRegistry } from 'react-native';
+import { NativeModules } from 'react-native';
 
-export interface Spec extends TurboModule {
+export interface P2PRuntimeNativeModule {
   /**
    * Spawn the Node child process.
    * nodeBin    — absolute path to the node binary
    * scriptPath — absolute path to child-bin.ts (or compiled .js in prod)
    * storage    — passed as an env var so the child can init Corestore
+   *              (unused by @workspace.sh/workspace's own child-bin, which
+   *              receives storage via the RPC payload instead — kept for
+   *              parity with the low-level protocol's child-bin.ts)
    */
   spawn(nodeBin: string, scriptPath: string, storage: string | null): Promise<void>;
 
@@ -28,9 +35,26 @@ export interface Spec extends TurboModule {
   /** Terminate the child and wait for it to exit. */
   close(): Promise<void>;
 
+  /**
+   * This device's persistent 32-byte identity seed, as hex. Get-or-create:
+   * generated via SecRandomCopyBytes and stored in the macOS Keychain on
+   * first call; the same seed is returned on every subsequent call. See
+   * docs/identity-recovery.md (device-linking flow).
+   */
+  identitySeed(): Promise<string>;
+
+  /**
+   * `<Application Support>/<bundle id>/p2p/<subpath>`, created if needed.
+   * Never default corestore storage into a workspace's own (possibly
+   * cloud-synced) folder — see docs/workspace-format.md invariant 4.
+   */
+  storagePath(subpath: string): Promise<string>;
+
   // ------ EventEmitter boilerplate (required by RN for native event modules) ------
   addListener(eventName: string): void;
   removeListeners(count: number): void;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('P2PRuntime');
+const NativeP2PRuntime: P2PRuntimeNativeModule = NativeModules.P2PRuntime;
+
+export default NativeP2PRuntime;

--- a/packages/p2p-runtime/src/ipc/child-bin.ts
+++ b/packages/p2p-runtime/src/ipc/child-bin.ts
@@ -10,11 +10,14 @@
 // stderr is `inherit`-friendly so debugging output from the child shows up
 // in the parent's terminal during development.
 
+import { createRuntime } from '../runtime.node.ts';
 import { Child } from './child.ts';
 
+// This entry point is the one that binds the runtime — `Child` itself takes it
+// as a parameter so the Bare worklet can bind a different one (#229).
 const child = new Child((s) => {
   process.stdout.write(s);
-});
+}, createRuntime);
 
 process.stdin.setEncoding('utf8');
 process.stdin.on('data', (chunk: string) => {

--- a/packages/p2p-runtime/src/ipc/child.ts
+++ b/packages/p2p-runtime/src/ipc/child.ts
@@ -1,12 +1,19 @@
-// Child worker. Wraps a NodeRuntime and serves the JSON-RPC protocol
-// (see ./protocol.ts) over stdin/stdout.
+// Child worker. Serves the JSON-RPC protocol (see ./protocol.ts) over whatever
+// byte channel the host hands it.
 //
-// The parent — whether a Node parent (tests + apps/node) or a future macOS
-// TurboModule parent — only ever sees the wire shape. The child code is
-// reused unchanged.
+// The parent — a Node parent (tests + apps/node), the macOS TurboModule
+// parent, or the in-process Bare host on iOS / Android — only ever sees the
+// wire shape. The child code is reused unchanged.
+//
+// The runtime is INJECTED rather than imported. This used to import
+// `NodeRuntime` directly, which quietly made every host a Node host: the Bare
+// worklet could not pack because the import dragged `node:*` builtins into a
+// graph that cannot resolve them (#229). Taking a factory keeps this file
+// honest about what it depends on — a `P2PRuntime`, not a particular host's
+// implementation of one — and matches the injection seam the rest of the
+// stack already uses (`RuntimeFactory`, `OpenWorkspaceFn`).
 
-import { NodeRuntime } from '../runtime.node.ts';
-import type { Log } from '../types.ts';
+import type { CreateRuntimeOptions, Log, P2PRuntime } from '../types.ts';
 import { encode, LineDecoder } from './framing.ts';
 import type {
   AppendBlockResult,
@@ -28,15 +35,23 @@ interface OpenLog {
   unsubscribe: () => void;
 }
 
+/**
+ * Creates a ready-to-use runtime. Supplied by the host so this module stays
+ * free of any particular host's imports.
+ */
+export type ChildRuntimeFactory = (opts: CreateRuntimeOptions) => Promise<P2PRuntime>;
+
 export class Child {
-  private runtime: NodeRuntime | null = null;
+  private runtime: P2PRuntime | null = null;
   private logs = new Map<Hex, OpenLog>();
   private decoder = new LineDecoder();
   private write: (s: string) => void;
+  private createRuntime: ChildRuntimeFactory;
   private shuttingDown = false;
 
-  constructor(write: (s: string) => void) {
+  constructor(write: (s: string) => void, createRuntime: ChildRuntimeFactory) {
     this.write = write;
+    this.createRuntime = createRuntime;
   }
 
   /** Feed a chunk read from stdin. Dispatches each complete message. */
@@ -63,8 +78,8 @@ export class Child {
         if (this.runtime) {
           return { did: this.runtime.did() } satisfies InitResult;
         }
-        this.runtime = new NodeRuntime({ storage: params.storage ?? undefined });
-        await this.runtime.ready();
+        // The factory returns a runtime that has already been readied.
+        this.runtime = await this.createRuntime({ storage: params.storage ?? undefined });
         return { did: this.runtime.did() } satisfies InitResult;
       }
       case 'did': {
@@ -136,7 +151,7 @@ export class Child {
     this.logs.set(log.key, { log, unsubscribe });
   }
 
-  private requireRuntime(): NodeRuntime {
+  private requireRuntime(): P2PRuntime {
     if (!this.runtime) throw new Error('runtime not initialised — send init first');
     return this.runtime;
   }

--- a/packages/p2p-runtime/src/ipc/index.ts
+++ b/packages/p2p-runtime/src/ipc/index.ts
@@ -1,0 +1,25 @@
+// Reusable IPC primitives — transport + wire framing, protocol-agnostic.
+//
+// Exposed as a package entry point (`@workspace.sh/p2p-runtime/ipc`) so other
+// packages can build their OWN JSON-RPC protocol over the same spawn/transport
+// mechanics without depending on this package's specific Log/runtime protocol.
+// `@workspace.sh/workspace`'s own IPC layer (a Workspace-level protocol, not a
+// Log-level one) is the first consumer — see packages/workspace/src/ipc/.
+//
+// Node-safe only. MacOSTransport imports 'react-native' at module-eval time
+// (ESM re-exports load eagerly, no tree-shaking under plain `node`), so it's
+// deliberately NOT re-exported here — import it from
+// `@workspace.sh/p2p-runtime/ipc/macos` instead, from a `.macos.ts`-suffixed
+// consumer file only (same split as runtime.node.ts / runtime.macos.ts).
+//
+// The same eager-evaluation caveat applies to NodeTransport below, in the
+// other direction: it pulls `node:child_process` / `node:url` / `node:path`,
+// none of which resolve under Bare, so importing this barrel from anything
+// that has to pack into a worklet breaks the mobile bundle. Child-side code
+// wants `@workspace.sh/p2p-runtime/ipc/framing`, which is just the wire
+// framing and nothing else (#229).
+
+export { encode, LineDecoder } from './framing.ts';
+export type { Transport } from './transport.ts';
+export { NodeTransport } from './transport.node.ts';
+export type { NodeTransportOptions } from './transport.node.ts';

--- a/packages/p2p-runtime/src/ipc/transport.ios.ts
+++ b/packages/p2p-runtime/src/ipc/transport.ios.ts
@@ -1,0 +1,126 @@
+// iOS/Android transport — bridges SpawnedRuntime to a Bare worklet.
+//
+// The macOS sibling (`transport.macos.ts`) adapts an NSTask child reached
+// through a TurboModule. This one adapts a `react-native-bare-kit` Worklet:
+// Bare runs in-process, so there is no process to spawn and no binary to
+// bundle — the "child" is a worklet started from a `bare-pack` bundle.
+//
+// The Transport contract is five members wide (send / onMessage / onExit /
+// close / closed), which is why the mobile path is an adapter rather than a
+// port. Nothing above this file changes.
+//
+// Naming: `.ios.ts` so Metro resolves it on iOS. Android takes the same
+// binding, so `runtime.android.ts` imports this module directly rather than
+// duplicating it under a second extension.
+
+import type { Transport } from './transport.ts';
+
+/** The slice of `react-native-bare-kit`'s Worklet we depend on. */
+export interface BareWorklet {
+  start(filename: string, source: ArrayBuffer | Uint8Array | string): void;
+  terminate(): Promise<void> | void;
+  readonly IPC: {
+    write(data: Uint8Array | string): void;
+    on(event: 'data', cb: (data: Uint8Array) => void): void;
+    on(event: 'close', cb: () => void): void;
+    end?(): void;
+  };
+}
+
+export interface BareTransportOptions {
+  /** A `new Worklet()` from `react-native-bare-kit`, injected so this module
+   *  stays importable (and testable) without the native dependency present. */
+  worklet: BareWorklet;
+  /** Path the worklet reports as its entry filename, e.g. `/app.bundle`. */
+  filename?: string;
+}
+
+export class BareTransport implements Transport {
+  private worklet: BareWorklet;
+  private filename: string;
+  private msgListeners = new Set<(msg: unknown) => void>();
+  private exitListeners = new Set<(code: number | null) => void>();
+  private _closed = false;
+  private decoder = new TextDecoder();
+  // Bare's IPC is a byte stream, not a message channel: a write on the worklet
+  // side can arrive here split across reads, or several coalesced into one.
+  // Same problem stdio has, and it gets the same fix — buffer until newline.
+  // Getting this wrong yields JSON.parse failures only under load, which is
+  // the worst way to find out.
+  private buffer = '';
+
+  constructor(opts: BareTransportOptions) {
+    this.worklet = opts.worklet;
+    this.filename = opts.filename ?? '/app.bundle';
+  }
+
+  /**
+   * Start the worklet from a `bare-pack` bundle. Must be called before the
+   * transport is handed to SpawnedRuntime.
+   *
+   * Listeners are attached before `start` so the first line can't be missed —
+   * the worklet begins executing immediately.
+   */
+  async start(bundle: ArrayBuffer | Uint8Array | string): Promise<void> {
+    this.worklet.IPC.on('data', (data: Uint8Array) => {
+      this.buffer += typeof data === 'string' ? data : this.decoder.decode(data);
+      const parts = this.buffer.split('\n');
+      this.buffer = parts.pop() ?? '';
+      for (const part of parts) {
+        if (!part) continue;
+        try {
+          const msg: unknown = JSON.parse(part);
+          for (const cb of this.msgListeners) cb(msg);
+        } catch {
+          // Malformed line — the worklet's console output goes to the system
+          // log, so diagnostics are there rather than in-band.
+        }
+      }
+    });
+
+    this.worklet.IPC.on('close', () => {
+      this.markClosed(null);
+    });
+
+    this.worklet.start(this.filename, bundle);
+  }
+
+  private markClosed(code: number | null): void {
+    if (this._closed) return;
+    this._closed = true;
+    for (const cb of this.exitListeners) cb(code);
+  }
+
+  get closed(): boolean {
+    return this._closed;
+  }
+
+  send(line: string): void {
+    if (this._closed) return;
+    this.worklet.IPC.write(line);
+  }
+
+  onMessage(cb: (msg: unknown) => void): () => void {
+    this.msgListeners.add(cb);
+    return () => {
+      this.msgListeners.delete(cb);
+    };
+  }
+
+  onExit(cb: (code: number | null) => void): () => void {
+    this.exitListeners.add(cb);
+    return () => {
+      this.exitListeners.delete(cb);
+    };
+  }
+
+  async close(): Promise<void> {
+    if (this._closed) return;
+    // Close the write side first so the worklet sees end-of-input and can
+    // shut down cleanly, mirroring how the macOS path closes stdin before
+    // terminating. Fall back to terminate() for an unresponsive worklet.
+    this.worklet.IPC.end?.();
+    await this.worklet.terminate();
+    this.markClosed(0);
+  }
+}

--- a/packages/p2p-runtime/src/ipc/worklet-bin.ts
+++ b/packages/p2p-runtime/src/ipc/worklet-bin.ts
@@ -1,0 +1,53 @@
+// Entry point for the Bare worklet — the iOS/Android counterpart to
+// `child-bin.ts`.
+//
+// The macOS path spawns a Node child and speaks JSON-RPC over stdin/stdout.
+// Mobile has no child processes, so `react-native-bare-kit` runs a Bare
+// instance *in-process* and gives it a bidirectional byte channel
+// (`BareKit.IPC`) instead of pipes. Everything above the byte channel is
+// identical: this file is `child-bin.ts` with the two lines that touch stdio
+// swapped for the two that touch IPC.
+//
+// That symmetry is the point. `Child` takes a write callback and a `feed()`
+// method and knows nothing about how bytes arrive, so the protocol, the
+// framing, and the runtime beneath are shared verbatim between platforms —
+// mobile is a different transport, not a different implementation.
+//
+// Bundled with `bare-pack`, which resolves the builtins the runtime uses
+// (fs, os, path) to their `bare-*` equivalents via this package's `imports`
+// map. `child_process` is NOT among them: it is used only by the Node *parent*
+// in `transport.node.ts`, never on the child side.
+//
+// That resolution only works because the runtime imports those builtins
+// UNPREFIXED and uses `b4a` rather than `Buffer`. It did neither before #229,
+// which is why this file had never successfully packed.
+
+// Bare provides no TextEncoder/TextDecoder globals, and this file runs inside
+// the Bare worklet on iOS/Android. b4a covers both hosts (#243).
+import b4a from 'b4a';
+
+import { createRuntime } from '../runtime.node.ts';
+import { Child } from './child.ts';
+
+declare const BareKit: {
+  IPC: {
+    write(data: Uint8Array | string): void;
+    on(event: 'data', cb: (data: Uint8Array) => void): void;
+    on(event: 'close', cb: () => void): void;
+  };
+};
+
+// Same runtime as the macOS child: `runtime.node.ts` is named for its original
+// host but is host-agnostic, so both entry points bind the same implementation.
+const child = new Child((s) => {
+  BareKit.IPC.write(s);
+}, createRuntime);
+
+BareKit.IPC.on('data', (data) => {
+  const chunk = typeof data === 'string' ? data : b4a.toString(data, 'utf8');
+  child.feed(chunk).catch((err: unknown) => {
+    // No stderr to inherit here — the host sees this through liblog, which is
+    // where console output from a worklet goes.
+    console.error(`[worklet] feed crashed: ${(err as Error).stack ?? String(err)}`);
+  });
+});

--- a/packages/p2p-runtime/src/runtime.android.ts
+++ b/packages/p2p-runtime/src/runtime.android.ts
@@ -1,12 +1,30 @@
-// Android implementation — STUB. Filled in during Phase 2 of PLAN.md.
-// Same shape as runtime.ios.ts; both target react-native-bare-kit.
+// Android implementation of @workspace.sh/p2p-runtime.
+//
+// Identical to iOS: `react-native-bare-kit` runs the same Bare worklet, over
+// the same IPC byte channel, driving the same `SpawnedRuntime`. Bare ships
+// Tier 1 Android prebuilds (arm, arm64, ia32, x64).
+//
+// Re-exported rather than reimplemented so the two platforms cannot drift.
+// If they ever need to diverge, this file is the seam to open — but a
+// duplicate that starts identical is a duplicate that silently stops being so.
+//
+// The remaining Android-specific unknowns are not in this layer: Doze-mode
+// battery restrictions on background sync (docs/risks.md §2), and the
+// `bare-pack --target android` bundle differing from the iOS one.
 
-import type { CreateRuntimeOptions, P2PRuntime } from './types.ts';
+export {
+  createRuntime,
+  SpawnedRuntime,
+  BareTransport,
+  type BareWorklet,
+  type IOSRuntimeOptions as AndroidRuntimeOptions,
+} from './runtime.ios.ts';
 
-export async function createRuntime(_opts: CreateRuntimeOptions = {}): Promise<P2PRuntime> {
-  throw new Error(
-    '[@workspace.sh/p2p-runtime/android] not implemented yet — Phase 2 of PLAN.md (react-native-bare-kit + bare-pack)',
-  );
-}
-
-export type { P2PRuntime, Log, Did, TopicId, LogKey, CreateRuntimeOptions } from './types.ts';
+export type {
+  P2PRuntime,
+  Log,
+  Did,
+  TopicId,
+  LogKey,
+  CreateRuntimeOptions,
+} from './types.ts';

--- a/packages/p2p-runtime/src/runtime.ios.ts
+++ b/packages/p2p-runtime/src/runtime.ios.ts
@@ -1,15 +1,61 @@
-// iOS implementation — STUB. Filled in during Phase 2 of PLAN.md.
+// iOS implementation of @workspace.sh/p2p-runtime.
 //
-// Plan: thin RPC client over BareKit IPC. The actual Hypercore stack runs
-// inside a Bare worklet packaged with `bare-pack`; this file is the host-side
-// surface that mirrors `runtime.node.ts`'s shape.
+// Mobile has no child processes, so instead of spawning Node via NSTask this
+// runs a Bare instance in-process through `react-native-bare-kit`. Bare ships
+// Tier 1 prebuilds for iOS (arm64 + simulator) and is what Keet uses in
+// production, so the Hypercore stack under it is a known quantity rather than
+// an experiment.
+//
+// Everything above the byte channel is shared with macOS: same JSON-RPC
+// protocol, same framing, same `SpawnedRuntime`. Only the transport differs —
+// which is the whole reason `Transport` exists as a five-member interface.
+//
+// Setup (host app):
+//   1. npm i react-native-bare-kit
+//   2. Bundle the worklet:  bare-pack --target ios --linked --out app.bundle \
+//        packages/p2p-runtime/src/ipc/worklet-bin.ts
+//   3. Load that bundle and pass it as `bundle` below, with a fresh Worklet.
+//
+// The bundle is passed in rather than read here so this module keeps no
+// opinion about asset loading — which differs between Expo, bare RN, and a
+// test harness.
 
+import { SpawnedRuntime } from './ipc/parent.ts';
+import { BareTransport, type BareWorklet } from './ipc/transport.ios.ts';
 import type { CreateRuntimeOptions, P2PRuntime } from './types.ts';
 
-export async function createRuntime(_opts: CreateRuntimeOptions = {}): Promise<P2PRuntime> {
-  throw new Error(
-    '[@workspace.sh/p2p-runtime/ios] not implemented yet — Phase 2 of PLAN.md (react-native-bare-kit + bare-pack)',
-  );
+export interface IOSRuntimeOptions extends CreateRuntimeOptions {
+  /** A `new Worklet()` from `react-native-bare-kit`. Injected so this module
+   *  never imports the native package directly, keeping it testable against a
+   *  fake and importable where the native side isn't installed. */
+  worklet: BareWorklet;
+
+  /** The `bare-pack` bundle for `worklet-bin.ts`. */
+  bundle: ArrayBuffer | Uint8Array | string;
+
+  /** Entry filename the worklet reports. Defaults to `/app.bundle`. */
+  filename?: string;
 }
 
-export type { P2PRuntime, Log, Did, TopicId, LogKey, CreateRuntimeOptions } from './types.ts';
+export async function createRuntime(opts: IOSRuntimeOptions): Promise<P2PRuntime> {
+  const transport = new BareTransport({
+    worklet: opts.worklet,
+    filename: opts.filename,
+  });
+  await transport.start(opts.bundle);
+
+  const runtime = new SpawnedRuntime({ transport, storage: opts.storage });
+  await runtime.ready();
+  return runtime;
+}
+
+export { SpawnedRuntime } from './ipc/parent.ts';
+export { BareTransport, type BareWorklet } from './ipc/transport.ios.ts';
+export type {
+  P2PRuntime,
+  Log,
+  Did,
+  TopicId,
+  LogKey,
+  CreateRuntimeOptions,
+} from './types.ts';

--- a/packages/p2p-runtime/src/runtime.macos.ts
+++ b/packages/p2p-runtime/src/runtime.macos.ts
@@ -49,7 +49,6 @@ export async function createRuntime(opts: MacOSRuntimeOptions): Promise<P2PRunti
 
 export { SpawnedRuntime } from './ipc/parent.ts';
 export { MacOSTransport } from './ipc/transport.macos.ts';
-export type { MacOSRuntimeOptions };
 export type {
   P2PRuntime,
   Log,

--- a/packages/p2p-runtime/src/runtime.node.ts
+++ b/packages/p2p-runtime/src/runtime.node.ts
@@ -1,24 +1,40 @@
-// Node implementation of @workspace.sh/p2p-runtime.
+// The Hypercore implementation of @workspace.sh/p2p-runtime.
 //
 // Used directly by:
 //   - the apps/node smoke harness (Phase 1 of PLAN.md)
 //   - the spawned Node child process on the macOS RN-host path (Phase 3)
+//   - the Bare worklet on iOS / Android, which runs in-process rather than as
+//     a child (see ipc/worklet-bin.ts)
+//
+// Named `.node` for its original host, but deliberately host-AGNOSTIC: the
+// builtins below are imported unprefixed so this package's `imports` map can
+// swap them for their `bare-*` equivalents under Bare, and bytes go through
+// `b4a` rather than the `Buffer` global, which Bare does not have. Keeping one
+// runtime for both hosts is what makes the "same code below the byte channel"
+// claim actually true — it was not, before #229.
+//
+// Do NOT reintroduce `node:`-prefixed specifiers or `Buffer` here. Both work
+// fine under Node and both silently break the mobile bundle.
 //
 // Deliberately small: every public method maps to a single corestore /
 // hyperswarm call. The whole point of this package is that the consuming app
 // shouldn't care about Hypercore at all, only about logs and topics.
 
-import { existsSync, mkdirSync, mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
-import { createRequire } from 'node:module';
+import { existsSync, mkdirSync, mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 import Corestore from 'corestore';
 import Hyperswarm from 'hyperswarm';
 import b4a from 'b4a';
 import Protomux from 'protomux';
 import c from 'compact-encoding';
+// Derives the swarm keypair from the corestore primaryKey so the Noise
+// identity and the did:key identity are the same key (see ready()). Imported
+// statically rather than through `createRequire`, which has no Bare
+// equivalent; it is a direct dependency for that reason.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import hypercoreCryptoModule from 'hypercore-crypto';
 
 import type {
   ConnectionAuth,
@@ -30,13 +46,10 @@ import type {
   TopicId,
 } from './types.ts';
 import { didFromPublicKey } from './did.ts';
+import { flushLogToDir, hydrateLogFromDir } from './transport-form.ts';
 
-const require = createRequire(import.meta.url);
-// hypercore-crypto is a transitive dep of corestore — used to derive the
-// swarm keypair from the corestore primaryKey so the Noise identity and the
-// did:key identity are the same key (see ready()).
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const hypercoreCrypto = require('hypercore-crypto') as any;
+const hypercoreCrypto = hypercoreCryptoModule as any;
 
 // How long to wait for a peer's membership proof before dropping a gated
 // connection. Generous — covers a slow handshake, well short of hanging.
@@ -67,6 +80,9 @@ class NodeLog implements Log {
   }
   get length(): number {
     return this.core.length;
+  }
+  get contiguousLength(): number {
+    return this.core.contiguousLength as number;
   }
 
   async append(block: Uint8Array): Promise<number> {
@@ -102,18 +118,25 @@ export class NodeRuntime implements P2PRuntime {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private store!: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private swarm!: any;
+  private swarm: any = null;
+  /** False makes this runtime local-only — see CreateRuntimeOptions.swarm. */
+  private wantSwarm = true;
   private storagePath: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private joinedTopics = new Map<string, any>();
   private logs = new Map<string, NodeLog>();
   private didCache: Did | null = null;
+  // Cold replicas used only to make flushing incremental — a rebuildable
+  // cache beside the main store, never inside a workspace folder.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private captureStore: any = null;
   private opened = false;
   private bootstrap: Array<{ host: string; port: number }> | undefined;
   private auth: ConnectionAuth | undefined;
   private identitySeed: Uint8Array | undefined;
 
   constructor(opts: CreateRuntimeOptions = {}) {
+    this.wantSwarm = opts.swarm !== false;
     const s = opts.storage;
     if (!s || s === ':memory:') {
       this.storagePath = mkdtempSync(join(tmpdir(), 'p2p-runtime-'));
@@ -139,7 +162,7 @@ export class NodeRuntime implements P2PRuntime {
     // deliberate: a fixed identitySeed is how a peer gets a deterministic DID.
     this.store = this.identitySeed
       ? new Corestore(this.storagePath, {
-          primaryKey: Buffer.from(this.identitySeed),
+          primaryKey: b4a.from(this.identitySeed),
           unsafe: true,
         })
       : new Corestore(this.storagePath);
@@ -153,30 +176,35 @@ export class NodeRuntime implements P2PRuntime {
     // makes topic-layer auth sound: a peer's authenticated connection key
     // matches the DID its membership UCAN is addressed to.
     const primaryKey = this.store.primaryKey as Uint8Array;
-    const keyPair = hypercoreCrypto.keyPair(Buffer.from(primaryKey)) as {
-      publicKey: Buffer;
-      secretKey: Buffer;
+    const keyPair = hypercoreCrypto.keyPair(b4a.from(primaryKey)) as {
+      publicKey: Uint8Array;
+      secretKey: Uint8Array;
     };
 
-    this.swarm = new Hyperswarm({
-      keyPair,
-      ...(this.bootstrap ? { bootstrap: this.bootstrap } : {}),
-    });
-    this.swarm.on('connection', (conn: unknown) => {
-      if (!this.auth) {
-        // Open swarm (default): every connection replicates immediately.
-        this.store.replicate(conn);
-        return;
-      }
-      // Gated: exchange + verify membership proofs before replicating.
-      this._gatedReplicate(conn).catch(() => {
-        try {
-          (conn as { destroy(err?: Error): void }).destroy(new Error('auth failed'));
-        } catch {
-          /* already gone */
-        }
+    // Local-only runtimes never build one. The keypair above is derived
+    // regardless, because the DID comes from the corestore primaryKey — the
+    // swarm merely reuses it as its Noise identity.
+    if (this.wantSwarm) {
+      this.swarm = new Hyperswarm({
+        keyPair,
+        ...(this.bootstrap ? { bootstrap: this.bootstrap } : {}),
       });
-    });
+      this.swarm.on('connection', (conn: unknown) => {
+        if (!this.auth) {
+          // Open swarm (default): every connection replicates immediately.
+          this.store.replicate(conn);
+          return;
+        }
+        // Gated: exchange + verify membership proofs before replicating.
+        this._gatedReplicate(conn).catch(() => {
+          try {
+            (conn as { destroy(err?: Error): void }).destroy(new Error('auth failed'));
+          } catch {
+            /* already gone */
+          }
+        });
+      });
+    }
 
     this.didCache = didFromPublicKey(keyPair.publicKey);
     this.opened = true;
@@ -271,9 +299,21 @@ export class NodeRuntime implements P2PRuntime {
     if (buf.length !== 32) {
       throw new Error(`Topic must be 32 bytes (64 hex chars), got ${buf.length} bytes`);
     }
+    // Deliberately after the length check: the existing validation tests pass
+    // a swarmless runtime a bad topic and assert the length message.
+    if (this.swarm === null) {
+      throw new Error(
+        'joinTopic requires a swarm — this runtime was created with `swarm: false` and is local-only',
+      );
+    }
     const discovery = this.swarm.join(buf, { server: true, client: true });
     this.joinedTopics.set(topic, discovery);
     await discovery.flushed();
+  }
+
+  /** See P2PRuntime.replicates — false when built with `swarm: false`. */
+  get replicates(): boolean {
+    return this.wantSwarm;
   }
 
   async leaveTopic(topic: TopicId): Promise<void> {
@@ -281,6 +321,26 @@ export class NodeRuntime implements P2PRuntime {
     if (!d) return;
     await d.destroy();
     this.joinedTopics.delete(topic);
+  }
+
+  private _captureStore(): unknown {
+    if (this.captureStore === null) {
+      this.captureStore = new Corestore(`${this.storagePath}-capture`);
+    }
+    return this.captureStore;
+  }
+
+  async flushLogToDir(key: LogKey, dir: string): Promise<{ written: number; length: number }> {
+    if (!this.opened) throw new Error('Runtime not ready');
+    return flushLogToDir(this.store, this._captureStore(), b4a.from(key, 'hex'), dir);
+  }
+
+  async hydrateLogFromDir(
+    key: LogKey,
+    dir: string,
+  ): Promise<{ applied: number; skipped: number; length: number }> {
+    if (!this.opened) throw new Error('Runtime not ready');
+    return hydrateLogFromDir(this.store, b4a.from(key, 'hex'), dir);
   }
 
   async close(): Promise<void> {
@@ -297,6 +357,14 @@ export class NodeRuntime implements P2PRuntime {
       } catch {
         /* ignore */
       }
+    }
+    if (this.captureStore) {
+      try {
+        await this.captureStore.close();
+      } catch {
+        /* ignore */
+      }
+      this.captureStore = null;
     }
     if (this.store) {
       try {

--- a/packages/p2p-runtime/src/seal.ts
+++ b/packages/p2p-runtime/src/seal.ts
@@ -15,12 +15,11 @@
 // are sealed under the relevant tier key before being appended; peers that
 // hold the key unseal on read. Without the key, blocks are opaque bytes.
 
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-
+import b4a from 'b4a';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const sodium = require('sodium-universal') as any;
+import sodiumModule from 'sodium-universal';
+
+const sodium = sodiumModule as any;
 
 const NONCE_BYTES = sodium.crypto_secretbox_NONCEBYTES as number;
 const KEY_BYTES = sodium.crypto_secretbox_KEYBYTES as number;
@@ -43,13 +42,13 @@ export function seal(plaintext: Uint8Array, key: Uint8Array): Uint8Array {
     throw new Error(`key must be ${KEY_BYTES} bytes, got ${key.length}`);
   }
 
-  const nonce = Buffer.alloc(NONCE_BYTES);
+  const nonce = b4a.alloc(NONCE_BYTES);
   sodium.randombytes_buf(nonce);
 
-  const cipher = Buffer.alloc(plaintext.length + MAC_BYTES);
-  sodium.crypto_secretbox_easy(cipher, Buffer.from(plaintext), nonce, Buffer.from(key));
+  const cipher = b4a.alloc(plaintext.length + MAC_BYTES);
+  sodium.crypto_secretbox_easy(cipher, b4a.from(plaintext), nonce, b4a.from(key));
 
-  const out = Buffer.alloc(NONCE_BYTES + cipher.length);
+  const out = b4a.alloc(NONCE_BYTES + cipher.length);
   nonce.copy(out, 0);
   cipher.copy(out, NONCE_BYTES);
   return new Uint8Array(out);
@@ -74,12 +73,12 @@ export function open(sealed: Uint8Array, key: Uint8Array): Uint8Array {
   const nonce = sealed.subarray(0, NONCE_BYTES);
   const cipher = sealed.subarray(NONCE_BYTES);
 
-  const plaintext = Buffer.alloc(cipher.length - MAC_BYTES);
+  const plaintext = b4a.alloc(cipher.length - MAC_BYTES);
   const ok = sodium.crypto_secretbox_open_easy(
     plaintext,
-    Buffer.from(cipher),
-    Buffer.from(nonce),
-    Buffer.from(key),
+    b4a.from(cipher),
+    b4a.from(nonce),
+    b4a.from(key),
   ) as boolean;
   if (!ok) {
     throw new Error('open failed — wrong key or tampered payload');

--- a/packages/p2p-runtime/src/shims/crypto.ts
+++ b/packages/p2p-runtime/src/shims/crypto.ts
@@ -1,0 +1,86 @@
+// A `crypto` stand-in for the Bare worklet.
+//
+// Bare has no `crypto` builtin, and one dependency in the UCAN graph reaches
+// for Node's: `multiformats` hashes with `crypto.createHash(...)` in
+// `hashes/sha2.js` and `hashes/sha1.js`. Those files live in node_modules,
+// so the host-conditional `imports` map that fixes our own sources (#229)
+// cannot reach them — bare-pack's `--imports` global override can, and this
+// is what it points at. See scripts/bare-imports.cjs.
+//
+// "Global" overstates the blast radius: those two multiformats files are the
+// only importers of `crypto` anywhere in the packed graph. Worth re-checking
+// if the dependency set changes:
+//
+//   grep -rlE "from '(node:)?crypto'|require\('(node:)?crypto'\)" node_modules/…
+//
+// Backed by sodium-universal, which is already a dependency, is already
+// Bare-native, and produces byte-identical digests to Node's createHash —
+// the same equivalence relied on for topic derivation in
+// @workspace.sh/workspace.
+
+import b4a from 'b4a';
+import sodiumModule from 'sodium-universal';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sodium = sodiumModule as any;
+
+interface Algorithm {
+  bytes: number;
+  hash(out: Uint8Array, input: Uint8Array): void;
+}
+
+const ALGORITHMS: Record<string, Algorithm> = {
+  sha256: {
+    bytes: sodium.crypto_hash_sha256_BYTES,
+    hash: (out, input) => sodium.crypto_hash_sha256(out, input),
+  },
+  sha512: {
+    bytes: sodium.crypto_hash_sha512_BYTES,
+    hash: (out, input) => sodium.crypto_hash_sha512(out, input),
+  },
+};
+
+/**
+ * The subset of Node's Hash that callers in this graph actually use:
+ * `createHash(alg).update(data).digest()`.
+ *
+ * sodium's hashes are one-shot, so chunks are buffered and hashed on digest.
+ * That differs from Node's streaming implementation in memory profile, not in
+ * output — and the inputs here are UCAN payloads, not large files.
+ */
+class Hash {
+  private readonly algorithm: Algorithm;
+  private readonly chunks: Uint8Array[] = [];
+
+  constructor(algorithm: Algorithm) {
+    this.algorithm = algorithm;
+  }
+
+  update(data: Uint8Array | string): this {
+    this.chunks.push(typeof data === 'string' ? b4a.from(data) : data);
+    return this;
+  }
+
+  digest(encoding?: string): Uint8Array | string {
+    const input = this.chunks.length === 1 ? this.chunks[0]! : b4a.concat(this.chunks);
+    const out = b4a.alloc(this.algorithm.bytes);
+    this.algorithm.hash(out, input);
+    return encoding ? b4a.toString(out, encoding) : out;
+  }
+}
+
+export function createHash(algorithm: string): Hash {
+  const alg = ALGORITHMS[algorithm];
+  if (!alg) {
+    // Deliberately loud. sodium omits SHA-1 because it is broken, so a caller
+    // asking for it needs a decision, not a silent fallback to wrong bytes.
+    throw new Error(
+      `crypto shim: unsupported algorithm '${algorithm}' (have: ${Object.keys(ALGORITHMS).join(', ')})`,
+    );
+  }
+  return new Hash(alg);
+}
+
+// multiformats does `import crypto from 'crypto'`, so the default export is
+// the one that matters; the named export is for parity with Node.
+export default { createHash };

--- a/packages/p2p-runtime/src/transport-form.ts
+++ b/packages/p2p-runtime/src/transport-form.ts
@@ -1,0 +1,215 @@
+// Flush / hydrate between a corestore-backed log and the transport form —
+// `.workspace/store/v1/<log-key>/<seq>` — defined in workspace-format.md
+// § `store/` (workspace-p2p-spike, ADR 0003).
+//
+// The transport form is the replication protocol, persisted. Flushing runs a
+// REAL in-process replication from the main store into a persistent capture
+// replica, and every proof message the capture replica verifies is written to
+// a sequence file. Hydration replays those files into a core exactly as a
+// replica applies messages from a live peer. Nothing here invents a
+// verification story: a cold replica verified each message once, so a cold
+// replica can verify it again.
+//
+// Hand-building per-index proofs against imagined reader state was tried
+// first and fails — the protocol interleaves upgrades with out-of-order
+// blocks, and each proof is shaped for a reader that has applied exactly the
+// preceding messages. Capture order IS the contract; sequence numbers order
+// the replay, not the blocks.
+//
+// Bare-portable on purpose: unprefixed builtins via the package `imports`
+// map, `b4a` for bytes. This code runs inside the mobile worklet.
+
+import { mkdir, readdir, readFile, rename, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+import b4a from 'b4a';
+import c from 'compact-encoding';
+// Deep import: hypercore has no exports map, and these are the protocol's
+// own message codecs — reusing them is the point.
+import { wire } from 'hypercore/lib/messages.js';
+
+/** File names are zero-padded so lexicographic order is replay order. */
+const SEQ_WIDTH = 6;
+
+const SEQ_RE = /^\d{6}$/;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Core = any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Corestore = any;
+
+export interface FlushResult {
+  /** Message files written by this flush. */
+  written: number;
+  /** The log length the transport form now covers. */
+  length: number;
+}
+
+export interface HydrateResult {
+  /** Messages that verified and were applied. */
+  applied: number;
+  /** Files that failed to decode or verify — torn writes, tampering. */
+  skipped: number;
+  /** The core's length after replay. */
+  length: number;
+}
+
+function seqName(n: number): string {
+  return String(n).padStart(SEQ_WIDTH, '0');
+}
+
+/**
+ * The next sequence number to write.
+ *
+ * Derived from the HIGHEST existing name, not the count. Counting assumes the
+ * numbering is dense, and it need not be: a skipped file, an interrupted
+ * write, or a sync engine's conflicted copy leaves a hole, after which the
+ * count points at a name that already exists and the next flush silently
+ * overwrites earlier messages.
+ */
+export function nextSeq(names: string[]): number {
+  let highest = -1;
+  for (const name of names) {
+    const value = Number(name);
+    if (Number.isInteger(value) && value > highest) highest = value;
+  }
+  return highest + 1;
+}
+
+async function listSeqFiles(dir: string): Promise<string[]> {
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch {
+    return [];
+  }
+  // Anything that is not a bare sequence number is ignored: temp files from
+  // an interrupted atomic write, and sync engines' conflicted-copy siblings.
+  return names.filter(n => SEQ_RE.test(n)).sort();
+}
+
+/** Replay message files into `core`, one verify per file, tolerant per-file. */
+async function replayInto(core: Core, dir: string): Promise<HydrateResult> {
+  let applied = 0;
+  let skipped = 0;
+  for (const name of await listSeqFiles(dir)) {
+    try {
+      const bytes = await readFile(join(dir, name));
+      const proof = c.decode(wire.data, bytes);
+      await core.core.verify(proof);
+      applied++;
+    } catch {
+      // A torn or tampered file. Skipping rather than aborting keeps a
+      // partially-synced folder useful; replication heals the rest.
+      skipped++;
+    }
+  }
+  return { applied, skipped, length: core.length as number };
+}
+
+/**
+ * Flush a log to its transport directory.
+ *
+ * `captureStore` is a SEPARATE corestore holding a cold replica per log — it
+ * is what makes flushing incremental and the files stable: its length is
+ * exactly what previous flushes have written, so only the delta produces new
+ * messages. If it has been lost (it is a cache), it self-heals by replaying
+ * the existing files first.
+ */
+export async function flushLogToDir(
+  store: Corestore,
+  captureStore: Corestore,
+  key: Uint8Array,
+  dir: string,
+): Promise<FlushResult> {
+  const main: Core = store.get({ key: b4a.from(key) });
+  await main.ready();
+  await mkdir(dir, { recursive: true });
+
+  const existing = await listSeqFiles(dir);
+  let seq = nextSeq(existing);
+
+  if (main.length === 0) {
+    await main.close();
+    return { written: 0, length: 0 };
+  }
+
+  const cap: Core = captureStore.get({ key: b4a.from(key) });
+  await cap.ready();
+
+  try {
+    if (cap.length === 0 && existing.length > 0) {
+      // The capture replica is a rebuildable cache; the folder is the record.
+      await replayInto(cap, dir);
+    }
+    if (cap.length >= main.length) {
+      return { written: 0, length: cap.length as number };
+    }
+
+    // Tap the capture replica's verify: every message it accepts from the
+    // live replication below is persisted, in acceptance order, atomically.
+    const written: number[] = [];
+    const origVerify = cap.core.verify.bind(cap.core);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    cap.core.verify = async (proof: any, from: any) => {
+      const result = await origVerify(proof, from);
+
+      // Allocate the sequence number SYNCHRONOUSLY, before any await.
+      //
+      // Block-carrying data messages bypass the replicator's rx lock and run
+      // many in flight, so this function genuinely runs concurrently. Reading
+      // `seq` on either side of an await let two invocations pick the same
+      // number, write the same temp file and rename onto each other —
+      // destroying one proof and leaving a hole in the numbering that the
+      // next flush would then overwrite from.
+      const mySeq = seq++;
+      const bytes = c.encode(wire.data, { ...proof, request: 0 });
+      const tmp = join(dir, `.tmp-${mySeq}`);
+      await writeFile(tmp, bytes);
+      await rename(tmp, join(dir, seqName(mySeq)));
+      written.push(mySeq);
+      return result;
+    };
+
+    const s1 = main.replicate(true);
+    const s2 = cap.replicate(false);
+    s1.pipe(s2).pipe(s1);
+    try {
+      await cap.download({ start: 0, end: main.length }).done();
+    } finally {
+      cap.core.verify = origVerify;
+      s1.destroy();
+      s2.destroy();
+    }
+
+    return { written: written.length, length: cap.length as number };
+  } finally {
+    await cap.close();
+    await main.close();
+  }
+}
+
+/**
+ * Hydrate a log from its transport directory.
+ *
+ * Replays the message files into `key`'s core in `store` — the operation a
+ * copied folder needs on a device that has never met the writer. Per-file
+ * tolerant: a torn tail or tampered file is skipped and the replay continues,
+ * yielding a valid-but-stale log that ordinary replication heals.
+ */
+export async function hydrateLogFromDir(
+  store: Corestore,
+  key: Uint8Array,
+  dir: string,
+): Promise<HydrateResult> {
+  const core: Core = store.get({ key: b4a.from(key) });
+  await core.ready();
+  try {
+    if ((await listSeqFiles(dir)).length === 0) {
+      return { applied: 0, skipped: 0, length: core.length as number };
+    }
+    return await replayInto(core, dir);
+  } finally {
+    await core.close();
+  }
+}

--- a/packages/p2p-runtime/src/types.ts
+++ b/packages/p2p-runtime/src/types.ts
@@ -22,6 +22,19 @@ export interface Log {
   readonly writable: boolean;
   /** Current length (in blocks) as observed locally. */
   readonly length: number;
+  /**
+   * Length of the verified prefix starting at block 0 — i.e. how far the log
+   * can be read without waiting on a peer.
+   *
+   * This differs from `length` whenever a block is missing or was rejected:
+   * hydrating a transport folder with a corrupt message file leaves exactly
+   * that shape. Reading past it blocks until some peer supplies the block,
+   * which for a local-only or offline log is forever.
+   *
+   * Optional so implementations without the notion (fakes, stubs) are
+   * unaffected; absent means "the whole log is readable".
+   */
+  readonly contiguousLength?: number;
 
   /** Append a single block. Returns the new length. Writable logs only. */
   append(block: Uint8Array): Promise<number>;
@@ -38,6 +51,13 @@ export interface Log {
 
 /** A P2P runtime — created once per app, owns identity + storage + swarm. */
 export interface P2PRuntime {
+  /**
+   * False when this runtime cannot replicate — created with `swarm: false`,
+   * or a platform stub. Callers should skip `joinTopic` rather than let it
+   * throw; absent means "yes", so existing runtimes are unaffected.
+   */
+  readonly replicates?: boolean;
+
   /** Resolves once the runtime is ready to serve calls. */
   ready(): Promise<void>;
 
@@ -55,6 +75,19 @@ export interface P2PRuntime {
 
   /** Leave a discovery topic. */
   leaveTopic(topic: TopicId): Promise<void>;
+
+  /**
+   * Flush a log to its transport-form directory
+   * (`.workspace/store/v1/<log-key>`) — workspace-format.md § `store/`,
+   * ADR 0003. Optional: implemented by runtimes that own a corestore.
+   */
+  flushLogToDir?(key: LogKey, dir: string): Promise<{ written: number; length: number }>;
+
+  /** Replay a transport-form directory into a log. Optional, as above. */
+  hydrateLogFromDir?(
+    key: LogKey,
+    dir: string,
+  ): Promise<{ applied: number; skipped: number; length: number }>;
 
   /** Tear down. After close() the runtime is unusable. */
   close(): Promise<void>;
@@ -87,6 +120,22 @@ export interface ConnectionAuth {
 
 /** Options passed to the per-platform factory. */
 export interface CreateRuntimeOptions {
+  /**
+   * Whether to stand up a Hyperswarm for peer discovery and replication.
+   * Defaults to true.
+   *
+   * When false the runtime is LOCAL-ONLY: logs, `did()`, flush and hydrate all
+   * work exactly as before, and `joinTopic` throws rather than silently doing
+   * nothing. `bootstrap` and `auth` have no effect.
+   *
+   * Worth turning off wherever nothing will replicate — the whole offline test
+   * suite, and any flush-only path. A Hyperswarm binds a UDP socket that
+   * survives `destroy()` (upstream, see #254), so a process that creates one
+   * cannot exit; and paying for a DHT node to copy a folder is waste even
+   * without that bug.
+   */
+  swarm?: boolean;
+
   /**
    * Storage location.
    * - On Node/macOS: a filesystem path. `:memory:` falls back to an OS tempdir.

--- a/packages/p2p-runtime/src/wrap.ts
+++ b/packages/p2p-runtime/src/wrap.ts
@@ -13,12 +13,11 @@
 // Ed25519 ↔ curve25519 conversion is handled internally so callers pass
 // ed25519 keys (the form Hypercore + did:key already produce).
 
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-
+import b4a from 'b4a';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const sodium = require('sodium-universal') as any;
+import sodiumModule from 'sodium-universal';
+
+const sodium = sodiumModule as any;
 
 const CURVE_PK_BYTES = sodium.crypto_box_PUBLICKEYBYTES as number;
 const CURVE_SK_BYTES = sodium.crypto_box_SECRETKEYBYTES as number;
@@ -44,11 +43,11 @@ export function wrap(plaintext: Uint8Array, recipientEdPublicKey: Uint8Array): U
     );
   }
 
-  const curvePk = Buffer.alloc(CURVE_PK_BYTES);
-  sodium.crypto_sign_ed25519_pk_to_curve25519(curvePk, Buffer.from(recipientEdPublicKey));
+  const curvePk = b4a.alloc(CURVE_PK_BYTES);
+  sodium.crypto_sign_ed25519_pk_to_curve25519(curvePk, b4a.from(recipientEdPublicKey));
 
-  const sealed = Buffer.alloc(plaintext.length + SEAL_OVERHEAD);
-  sodium.crypto_box_seal(sealed, Buffer.from(plaintext), curvePk);
+  const sealed = b4a.alloc(plaintext.length + SEAL_OVERHEAD);
+  sodium.crypto_box_seal(sealed, b4a.from(plaintext), curvePk);
   return new Uint8Array(sealed);
 }
 
@@ -74,16 +73,16 @@ export function unwrap(sealed: Uint8Array, recipientEdSecretKey: Uint8Array): Ui
   // Sodium's ed25519 secret-key form is 32-byte seed || 32-byte pubkey.
   const edPk = recipientEdSecretKey.subarray(32, 64);
 
-  const curvePk = Buffer.alloc(CURVE_PK_BYTES);
-  sodium.crypto_sign_ed25519_pk_to_curve25519(curvePk, Buffer.from(edPk));
+  const curvePk = b4a.alloc(CURVE_PK_BYTES);
+  sodium.crypto_sign_ed25519_pk_to_curve25519(curvePk, b4a.from(edPk));
 
-  const curveSk = Buffer.alloc(CURVE_SK_BYTES);
-  sodium.crypto_sign_ed25519_sk_to_curve25519(curveSk, Buffer.from(recipientEdSecretKey));
+  const curveSk = b4a.alloc(CURVE_SK_BYTES);
+  sodium.crypto_sign_ed25519_sk_to_curve25519(curveSk, b4a.from(recipientEdSecretKey));
 
-  const plaintext = Buffer.alloc(sealed.length - SEAL_OVERHEAD);
+  const plaintext = b4a.alloc(sealed.length - SEAL_OVERHEAD);
   const ok = sodium.crypto_box_seal_open(
     plaintext,
-    Buffer.from(sealed),
+    b4a.from(sealed),
     curvePk,
     curveSk,
   ) as boolean;

--- a/packages/p2p-runtime/tests/encrypted-log.test.ts
+++ b/packages/p2p-runtime/tests/encrypted-log.test.ts
@@ -126,8 +126,8 @@ test('caller mutating the key buffer afterwards does not affect the wrapper', as
 // ---------------------------------------------------------------------------
 
 test('encrypted log replicates: B decrypts with the key, raw replica is ciphertext', async (t) => {
-  const a = new NodeRuntime({ storage: ':memory:' });
-  const b = new NodeRuntime({ storage: ':memory:' });
+  const a = new NodeRuntime({ storage: ':memory:', swarm: false });
+  const b = new NodeRuntime({ storage: ':memory:', swarm: false });
   await a.ready();
   await b.ready();
   const close = a.__pipeReplicate(b);

--- a/packages/p2p-runtime/tests/replicate.test.ts
+++ b/packages/p2p-runtime/tests/replicate.test.ts
@@ -18,7 +18,7 @@ const dec = new TextDecoder();
 const enc = new TextEncoder();
 
 async function fresh(): Promise<NodeRuntime> {
-  const r = new NodeRuntime({ storage: ':memory:' });
+  const r = new NodeRuntime({ storage: ':memory:', swarm: false });
   await r.ready();
   return r;
 }

--- a/packages/p2p-runtime/tests/shims-crypto.test.ts
+++ b/packages/p2p-runtime/tests/shims-crypto.test.ts
@@ -1,0 +1,55 @@
+// The crypto shim substitutes for Node's `crypto` inside the Bare worklet,
+// where no such module exists (#243). It is reached only through bare-pack's
+// --imports override, so nothing else in the test suite would catch a
+// regression in it — and a wrong digest here would silently corrupt UCAN
+// CIDs rather than fail loudly.
+//
+// The contract is equivalence with Node's createHash, so that is what these
+// assert, against Node's own implementation.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash as nodeCreateHash } from 'node:crypto';
+
+import { createHash } from '../src/shims/crypto.ts';
+
+const VECTORS = ['', 'a', 'hello from bare', 'workspace://z6MkpKpf2nFiC5h9qDPgJrkBbYBaThkAEcVCgGuBHkXqK4Vc'];
+
+for (const algorithm of ['sha256', 'sha512'] as const) {
+  test(`${algorithm}: matches node:crypto for representative inputs`, () => {
+    for (const input of VECTORS) {
+      const expected = nodeCreateHash(algorithm).update(input).digest();
+      const actual = createHash(algorithm).update(input).digest() as Uint8Array;
+      assert.deepEqual(
+        Buffer.from(actual),
+        expected,
+        `${algorithm} mismatch for ${JSON.stringify(input)}`,
+      );
+    }
+  });
+
+  test(`${algorithm}: chunked update matches a single update`, () => {
+    // multiformats calls update() once, but Node's contract allows many and
+    // the shim buffers rather than streaming — worth pinning.
+    const whole = createHash(algorithm).update('hello from bare').digest() as Uint8Array;
+    const chunked = createHash(algorithm)
+      .update('hello ')
+      .update('from ')
+      .update('bare')
+      .digest() as Uint8Array;
+    assert.deepEqual(Buffer.from(chunked), Buffer.from(whole));
+  });
+
+  test(`${algorithm}: hex encoding matches node:crypto`, () => {
+    const expected = nodeCreateHash(algorithm).update('hello from bare').digest('hex');
+    const actual = createHash(algorithm).update('hello from bare').digest('hex');
+    assert.equal(actual, expected);
+  });
+}
+
+test('an unsupported algorithm throws rather than returning wrong bytes', () => {
+  // sodium omits SHA-1 deliberately. Failing loudly is the point: a silent
+  // fallback would produce a plausible digest that is not a SHA-1.
+  assert.throws(() => createHash('sha1'), /unsupported algorithm 'sha1'/);
+  assert.throws(() => createHash('md5'), /unsupported algorithm 'md5'/);
+});

--- a/packages/p2p-runtime/tests/transport-form.test.ts
+++ b/packages/p2p-runtime/tests/transport-form.test.ts
@@ -1,0 +1,194 @@
+// Regression cover for the transport form's two silent-corruption bugs and
+// its unbounded wait (#254).
+//
+// All three shipped in #250 and none had a test. They are the kind that leave
+// no trace at the time: a proof destroyed by a filename collision, a flush
+// that overwrites earlier messages, a close that never returns.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import Corestore from 'corestore';
+import b4a from 'b4a';
+
+import { flushLogToDir, hydrateLogFromDir, nextSeq } from '../src/transport-form.ts';
+
+/**
+ * A temp base plus a `store()` factory whose corestores are ALWAYS closed,
+ * including when an assertion throws.
+ *
+ * Not incidental hygiene: RocksDB keeps the directory open, so a store left
+ * behind makes cleanup fail with ENOTEMPTY and — in a bigger suite — keeps
+ * the test process alive past the run.
+ */
+async function withBase(
+  fn: (base: string, store: (name: string) => Corestore) => Promise<void>,
+): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'tf-test-'));
+  const opened: Corestore[] = [];
+  const store = (name: string): Corestore => {
+    const s = new Corestore(join(base, name));
+    opened.push(s);
+    return s;
+  };
+  try {
+    await fn(base, store);
+  } finally {
+    for (const s of opened) {
+      try {
+        await s.close();
+      } catch {
+        /* already closed */
+      }
+    }
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// nextSeq — the overwrite bug
+// ---------------------------------------------------------------------------
+
+test('nextSeq continues past the highest name, not the count', () => {
+  // `existing.length` was the original derivation. With a hole it points at a
+  // name that already exists, so the next flush overwrites earlier messages.
+  assert.equal(nextSeq([]), 0);
+  assert.equal(nextSeq(['000000', '000001', '000002']), 3);
+  assert.equal(nextSeq(['000000', '000001', '000003']), 4, 'a hole must not cause reuse');
+  assert.equal(nextSeq(['000005']), 6, 'a sparse tail must not cause reuse');
+});
+
+// ---------------------------------------------------------------------------
+// The round trip still works
+// ---------------------------------------------------------------------------
+
+test('flush then hydrate reproduces the log on a cold store', async () => {
+  await withBase(async (base, store) => {
+    const a = store('a');
+    const core = a.get({ name: 'data' });
+    await core.ready();
+    await core.append(['one', 'two', 'three'].map(t => b4a.from(t)));
+    const key = core.key as Uint8Array;
+
+    const dir = join(base, 'store', 'v1', b4a.toString(key, 'hex'));
+    const r = await flushLogToDir(a, store('a-cap'), key, dir);
+    assert.ok(r.written > 0, 'flush wrote nothing');
+
+    const b = store('b');
+    const h = await hydrateLogFromDir(b, key, dir);
+    assert.equal(h.skipped, 0);
+    const replica = b.get({ key: b4a.from(key) });
+    await replica.ready();
+    assert.equal(replica.length, 3);
+    assert.equal(b4a.toString(await replica.get(0, { wait: false }), 'utf8'), 'one');
+    assert.equal(b4a.toString(await replica.get(2, { wait: false }), 'utf8'), 'three');
+  });
+});
+
+test('every written file has a unique name — no proof is lost to a collision', async () => {
+  // The original tap read `seq` on either side of two awaits, so concurrent
+  // verifies collided on the filename and one proof was silently destroyed.
+  // Enough blocks here to put many messages in flight at once.
+  await withBase(async (base, store) => {
+    const a = store('a');
+    const core = a.get({ name: 'data' });
+    await core.ready();
+    await core.append(Array.from({ length: 60 }, (_, i) => b4a.from(`block ${i}`)));
+    const key = core.key as Uint8Array;
+
+    const dir = join(base, 'store', 'v1', b4a.toString(key, 'hex'));
+    await flushLogToDir(a, store('a-cap'), key, dir);
+
+    const names = (await readdir(dir)).filter(n => /^\d{6}$/.test(n));
+    assert.equal(new Set(names).size, names.length, 'duplicate sequence names');
+    // Every file must be non-empty: a collision truncates or clobbers one.
+    for (const n of names) {
+      const bytes = await readFile(join(dir, n));
+      assert.ok(bytes.byteLength > 0, `${n} is empty`);
+    }
+
+    // And the whole thing must still replay.
+    const b = store('b');
+    const h = await hydrateLogFromDir(b, key, dir);
+    assert.equal(h.skipped, 0, 'a corrupted file would be skipped here');
+    assert.equal(h.length, 60);
+  });
+});
+
+test('a second flush appends rather than overwriting, even with a hole', async () => {
+  await withBase(async (base, store) => {
+    const a = store('a');
+    const cap = store('a-cap');
+    const core = a.get({ name: 'data' });
+    await core.ready();
+    await core.append([b4a.from('first')]);
+    const key = core.key as Uint8Array;
+    const dir = join(base, 'store', 'v1', b4a.toString(key, 'hex'));
+
+    await flushLogToDir(a, cap, key, dir);
+    const afterFirst = (await readdir(dir)).filter(n => /^\d{6}$/.test(n)).sort();
+    const firstContents = await Promise.all(
+      afterFirst.map(n => readFile(join(dir, n)).then(b => b4a.toString(b, 'hex'))),
+    );
+
+    await core.append([b4a.from('second')]);
+    await flushLogToDir(a, cap, key, dir);
+
+    // Everything written by the first flush must be byte-identical still.
+    for (const [i, n] of afterFirst.entries()) {
+      const now = b4a.toString(await readFile(join(dir, n)), 'hex');
+      assert.equal(now, firstContents[i], `${n} was overwritten by the second flush`);
+    }
+  });
+});
+
+test('flushing an unchanged log writes nothing and settles', async () => {
+  await withBase(async (base, store) => {
+    const a = store('a');
+    const cap = store('a-cap');
+    const core = a.get({ name: 'data' });
+    await core.ready();
+    await core.append([b4a.from('x')]);
+    const key = core.key as Uint8Array;
+    const dir = join(base, 'store', 'v1', b4a.toString(key, 'hex'));
+
+    await flushLogToDir(a, cap, key, dir);
+    const second = await flushLogToDir(a, cap, key, dir);
+    assert.equal(second.written, 0);
+  });
+});
+
+test('an empty log flushes without opening a capture session', async () => {
+  await withBase(async (base, store) => {
+    const a = store('a');
+    const core = a.get({ name: 'empty' });
+    await core.ready();
+    const dir = join(base, 'store', 'v1', b4a.toString(core.key as Uint8Array, 'hex'));
+    const r = await flushLogToDir(a, store('a-cap'), core.key as Uint8Array, dir);
+    assert.deepEqual(r, { written: 0, length: 0 });
+  });
+});
+
+test('hydrate ignores names that are not bare sequence numbers', async () => {
+  // Sync engines leave conflicted copies beside the real files.
+  await withBase(async (base, store) => {
+    const a = store('a');
+    const core = a.get({ name: 'data' });
+    await core.ready();
+    await core.append(['one', 'two'].map(t => b4a.from(t)));
+    const key = core.key as Uint8Array;
+    const dir = join(base, 'store', 'v1', b4a.toString(key, 'hex'));
+    await flushLogToDir(a, store('a-cap'), key, dir);
+
+    await writeFile(join(dir, '000000 (Leslie conflicted copy 2026-08-22)'), 'junk');
+    await writeFile(join(dir, '.tmp-9'), 'interrupted');
+
+    const b = store('b');
+    const h = await hydrateLogFromDir(b, key, dir);
+    assert.equal(h.skipped, 0, 'non-sequence names must be ignored, not skipped');
+    assert.equal(h.length, 2);
+  });
+});

--- a/packages/portable-bootstrap/src/conformance/invariants.ts
+++ b/packages/portable-bootstrap/src/conformance/invariants.ts
@@ -1,0 +1,277 @@
+// Conformance checks for the `.workspace` format invariants.
+//
+// docs/workspace-format.md opens with six numbered invariants and says why
+// they are written down:
+//
+//   "They exist so the metaphor is tested against, not re-litigated, each
+//    time a decision comes up."
+//
+// "Tested against" was aspirational until now. Invariant 6 was violated by
+// the very script it held up as the example — the mobile seed copied
+// `.workspace/keys/`, a peer's own identity, onto every device it seeded
+// (workspace-sh/workspace#233). The invariant was written, published, and
+// pointed at the file that broke it. Prose cannot enforce anything; this
+// module is the enforcement.
+//
+// Deliberately a LIBRARY rather than a test file. The value is in pointing it
+// at any tree that claims to be a workspace — one the app just created, one
+// that survived a `cp -R`, or the output of a seed or export path — rather
+// than at one writer's happy path. Export paths are exactly where invariant 6
+// failed, and a test that only covers `writeBundleFolder` would not have
+// caught it.
+//
+// Scope is on-disk SHAPE. The cryptography has its own tests; this asks
+// whether the bytes are arranged the way the format promises.
+
+import { readdir, readFile, stat } from 'fs/promises';
+import { join, relative, sep } from 'path';
+
+/** A single invariant violation. */
+export interface Violation {
+  /** Which numbered invariant from workspace-format.md was broken. */
+  invariant: number;
+  /** Workspace-relative path of the offending entry, or '' for the tree. */
+  path: string;
+  /** What is wrong, in terms someone can act on. */
+  message: string;
+}
+
+export interface CheckOptions {
+  /**
+   * Treat the tree as an export/transport artefact rather than a live
+   * workspace — i.e. one that should carry no `.workspace/` at all.
+   *
+   * The default (`false`) checks a working workspace: `.workspace/` is
+   * expected, but `keys/` still must not be present if the tree came from
+   * anywhere other than this device.
+   */
+  export?: boolean;
+}
+
+const META_DIR = '.workspace';
+
+/** Files inside `.workspace/` that the format defines. */
+const KNOWN_META_ENTRIES = new Set([
+  'manifest.json',
+  'attestation.json',
+  'policy.json',
+  'envelopes',
+  'keys',
+  'store',
+]);
+
+/**
+ * Mutable state files break invariant 4: append-only and content-addressed
+ * layouts tolerate a cloud-sync race, lock files do not. Matched by suffix
+ * because the names vary but the shapes do not.
+ */
+const LOCK_SUFFIXES = ['.lock', '.lck', '.pid', '.tmp'];
+
+/**
+ * Check a workspace tree against the format invariants.
+ *
+ * Returns every violation rather than throwing on the first, so a caller sees
+ * the whole picture in one pass.
+ */
+export async function checkWorkspaceInvariants(
+  workspaceDir: string,
+  options: CheckOptions = {},
+): Promise<Violation[]> {
+  const violations: Violation[] = [];
+  const metaDir = join(workspaceDir, META_DIR);
+
+  const metaExists = await isDirectory(metaDir);
+
+  if (options.export) {
+    // An export has left the container behind: no metadata, no keys, no
+    // encrypted store — "just data on disk", per the format doc.
+    if (metaExists) {
+      violations.push({
+        invariant: 6,
+        path: META_DIR,
+        message:
+          'an exported tree must not carry .workspace/ — export plaintext and ' +
+          'copy-the-folder are different operations and must not be conflated',
+      });
+    }
+  } else if (!metaExists) {
+    violations.push({
+      invariant: 1,
+      path: '',
+      message: 'no .workspace/ directory — not a workspace',
+    });
+  }
+
+  // Invariant 1: all machinery lives in ONE hidden directory. A metadata file
+  // scattered next to content is the failure this forbids.
+  // Invariant 6: keys never travel.
+  // Invariant 4: no mutable lock/state files anywhere in the container.
+  await walk(workspaceDir, workspaceDir, violations, options);
+
+  if (metaExists && !options.export) {
+    await checkMetaDir(workspaceDir, metaDir, violations);
+  }
+
+  return violations;
+}
+
+async function checkMetaDir(
+  root: string,
+  metaDir: string,
+  violations: Violation[],
+): Promise<void> {
+  const entries = await readdir(metaDir);
+
+  // The two files that make a workspace identifiable at all.
+  for (const required of ['manifest.json', 'attestation.json']) {
+    if (!entries.includes(required)) {
+      violations.push({
+        invariant: 1,
+        path: join(META_DIR, required),
+        message: `missing ${required} — a workspace cannot be identified without it`,
+      });
+    }
+  }
+
+  for (const entry of entries) {
+    if (KNOWN_META_ENTRIES.has(entry)) continue;
+    violations.push({
+      invariant: 1,
+      path: join(META_DIR, entry),
+      message:
+        `unrecognised entry in .workspace/ — as the metadata surface grows it ` +
+        `grows inside this directory, but every entry should be one the format defines`,
+    });
+  }
+
+  // Invariant 5: a plain `cp -R` must produce a valid workspace, so nothing
+  // in here may be unreadable without the app present.
+  const manifestPath = join(metaDir, 'manifest.json');
+  if (entries.includes('manifest.json')) {
+    try {
+      const text = await readFile(manifestPath, 'utf8');
+      const manifest = JSON.parse(text) as Record<string, unknown>;
+      for (const field of ['formatVersion', 'workspaceId', 'rootDid']) {
+        if (manifest[field] === undefined) {
+          violations.push({
+            invariant: 1,
+            path: join(META_DIR, 'manifest.json'),
+            message: `manifest is missing '${field}'`,
+          });
+        }
+      }
+      // Every log the manifest names must have its transport directory. A
+      // manifest pointing at logs with no store behind it is the 8 KB-stub
+      // failure this suite originally waved through (#249): the folder
+      // claims to be a workspace while its data lives on another machine.
+      const logs = manifest.logs as Record<string, string> | undefined;
+      if (logs && typeof logs === 'object') {
+        for (const [name, key] of Object.entries(logs)) {
+          if (typeof key !== 'string' || key.length === 0) continue;
+          if (!(await isDirectory(join(metaDir, 'store', 'v1', key)))) {
+            violations.push({
+              invariant: 5,
+              path: join(META_DIR, 'store', 'v1', key),
+              message:
+                `manifest names a '${name}' log but its transport directory is ` +
+                `absent — a copy of this folder cannot carry the workspace's data`,
+            });
+          }
+        }
+      }
+    } catch (err) {
+      violations.push({
+        invariant: 5,
+        path: relative(root, manifestPath),
+        message: `manifest.json is not readable JSON: ${(err as Error).message}`,
+      });
+    }
+  }
+}
+
+async function walk(
+  root: string,
+  dir: string,
+  violations: Violation[],
+  options: CheckOptions,
+): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    const rel = relative(root, full);
+    const segments = rel.split(sep);
+    const metaIndex = segments.indexOf(META_DIR);
+    const insideMeta = metaIndex !== -1;
+
+    // Invariant 6. Checked by path segment, not basename: a working tree may
+    // legitimately hold a folder called `keys/`, and only
+    // `.workspace/keys` is private key state.
+    if (insideMeta && segments[metaIndex + 1] === 'keys') {
+      violations.push({
+        invariant: 6,
+        path: rel,
+        message:
+          'this peer\'s private key state must never travel to another device — ' +
+          'in any mode, behind any flag',
+      });
+      continue; // No point descending; the whole subtree is the violation.
+    }
+
+    // Invariant 4. A mutable lock or pid file cannot survive a cloud-sync
+    // race, and the format has none by design.
+    if (LOCK_SUFFIXES.some(suffix => entry.endsWith(suffix))) {
+      violations.push({
+        invariant: 4,
+        path: rel,
+        message:
+          `mutable state file — append-only and content-addressed layouts ` +
+          `tolerate Dropbox/iCloud sync races, lock files do not`,
+      });
+    }
+
+    // Invariant 1. A stray dotfile beside content is metadata that escaped
+    // the one directory it is allowed to live in.
+    if (!insideMeta && entry.startsWith('.workspace') && entry !== META_DIR) {
+      violations.push({
+        invariant: 1,
+        path: rel,
+        message:
+          'workspace metadata outside .workspace/ — all machinery lives in ' +
+          'one hidden directory, never scattered beside content',
+      });
+    }
+
+    if (await isDirectory(full)) {
+      await walk(root, full, violations, options);
+    }
+  }
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Throw if `workspaceDir` violates any invariant. For use in test suites. */
+export async function assertWorkspaceInvariants(
+  workspaceDir: string,
+  options: CheckOptions = {},
+): Promise<void> {
+  const violations = await checkWorkspaceInvariants(workspaceDir, options);
+  if (violations.length === 0) return;
+  const lines = violations.map(
+    v => `  invariant ${v.invariant}: ${v.path || '<tree>'} — ${v.message}`,
+  );
+  throw new Error(
+    `${violations.length} .workspace format violation(s):\n${lines.join('\n')}`,
+  );
+}

--- a/packages/portable-bootstrap/src/folder.ts
+++ b/packages/portable-bootstrap/src/folder.ts
@@ -18,8 +18,8 @@
 //
 // See docs/workspace-format.md for the full on-disk layout.
 
-import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, readFile, readdir, writeFile } from 'fs/promises';
+import { join } from 'path';
 
 import {
   serialiseBundle,

--- a/packages/portable-bootstrap/src/index.ts
+++ b/packages/portable-bootstrap/src/index.ts
@@ -67,6 +67,12 @@ export interface Manifest {
     data: string;
     /** The live key delivery log (#9). */
     keyDelivery: string;
+    /**
+     * Binary content (#234). Optional: a workspace created before blob
+     * support has none, and opening one must keep working — writing a blob
+     * to it is what fails, with an explanation.
+     */
+    blobs?: string;
   };
 }
 
@@ -125,7 +131,7 @@ export interface CreateBundleInput {
   /** One envelope produced per recipient. */
   recipients: readonly RecipientInput[];
   /** Optional well-known log keys recorded in the manifest. */
-  logs?: { data: string; keyDelivery: string };
+  logs?: { data: string; keyDelivery: string; blobs?: string };
 }
 
 const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
@@ -469,3 +475,10 @@ export type {
   VerifyMembershipInput,
   MembershipVerdict,
 } from './membership.ts';
+
+export {
+  assertWorkspaceInvariants,
+  checkWorkspaceInvariants,
+  type CheckOptions,
+  type Violation,
+} from './conformance/invariants.ts';

--- a/packages/portable-bootstrap/src/key-delivery.ts
+++ b/packages/portable-bootstrap/src/key-delivery.ts
@@ -20,6 +20,10 @@
 //
 // See docs/permissions-model.md ("The two carriers") for the design.
 
+// Bare provides no TextEncoder/TextDecoder globals, and this file runs inside
+// the Bare worklet on iOS/Android. b4a covers both hosts (#243).
+import b4a from 'b4a';
+
 import type { Log, Did } from '@workspace.sh/p2p-runtime';
 
 import {
@@ -42,9 +46,6 @@ interface DeliveryRecord {
   envelope: SerialisedEnvelope;
 }
 
-const encoder = new TextEncoder();
-const decoder = new TextDecoder();
-
 /**
  * Append a sealed envelope to the key delivery log. Returns the log's new
  * length. The envelope is produced exactly as a bundle envelope is — see
@@ -58,7 +59,7 @@ export async function publishDelivery(log: Log, envelope: Envelope): Promise<num
     kind: DELIVERY_KIND,
     envelope: serialiseEnvelope(envelope),
   };
-  return log.append(encoder.encode(JSON.stringify(record)));
+  return log.append(b4a.from(JSON.stringify(record)));
 }
 
 /** A delivery that was addressed to the scanning peer and validated. */
@@ -122,7 +123,7 @@ export async function scanDeliveries(
   for (let index = from; index < to; index++) {
     let record: DeliveryRecord;
     try {
-      const parsed = JSON.parse(decoder.decode(await log.get(index))) as Partial<DeliveryRecord>;
+      const parsed = JSON.parse(b4a.toString(await log.get(index), 'utf8')) as Partial<DeliveryRecord>;
       if (parsed.kind !== DELIVERY_KIND || !parsed.envelope) {
         continue; // not a key-delivery block (e.g. a future revocation block)
       }

--- a/packages/portable-bootstrap/tests/conformance.test.ts
+++ b/packages/portable-bootstrap/tests/conformance.test.ts
@@ -1,0 +1,227 @@
+// Tests for the format-invariant conformance checker.
+//
+// Two halves, and the second is the point:
+//
+//   1. A workspace this codebase produces satisfies the invariants.
+//   2. A workspace that violates one is CAUGHT. A checker that only ever
+//      sees good input proves nothing — #233 happened because everyone
+//      looked at the happy path.
+//
+// The `keys/` case below is the real bug, reconstructed: a tree that has had
+// `.workspace/keys/` copied into it, which is exactly what the mobile seed
+// produced on every device it touched.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { principalFromSeed } from '@workspace.sh/ucan-boundary';
+import {
+  assertWorkspaceInvariants,
+  checkWorkspaceInvariants,
+  createBundle,
+  writeBundleFolder,
+  type CapabilityDescriptor,
+} from '../src/index.ts';
+
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const hypercoreCrypto = require('hypercore-crypto') as any;
+
+const RESOURCE = 'workspace://wid-conformance/data';
+const CAN: CapabilityDescriptor = { can: 'workspace/read', with: RESOURCE };
+
+function seededKey(byte: number): { publicKey: Buffer; secretKey: Buffer } {
+  const seed = new Uint8Array(32);
+  seed.fill(byte);
+  return hypercoreCrypto.keyPair(Buffer.from(seed)) as {
+    publicKey: Buffer;
+    secretKey: Buffer;
+  };
+}
+
+/** A real workspace on disk, with a small working tree beside the container. */
+async function makeWorkspace(fn: (dir: string) => Promise<void>): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'ws-conformance-'));
+  const dir = join(base, 'acme.workspace');
+  try {
+    const rootKp = seededKey(41);
+    const aliceKp = seededKey(42);
+    const root = await principalFromSeed(rootKp.secretKey.subarray(0, 32));
+    const alice = await principalFromSeed(aliceKp.secretKey.subarray(0, 32));
+    const k0 = new Uint8Array(32);
+    crypto.getRandomValues(k0);
+
+    const bundle = await createBundle({
+      workspaceId: 'wid-conformance',
+      createdAt: 1717200000,
+      root,
+      rootSecretKey: rootKp.secretKey,
+      recipients: [{ did: alice.did(), resource: RESOURCE, key: k0, capability: CAN }],
+    });
+    await writeBundleFolder(bundle, dir);
+
+    // A plausible working tree, including a decoy `keys/` folder that a user
+    // may legitimately have and which must NOT be flagged.
+    await mkdir(join(dir, 'policies'), { recursive: true });
+    await writeFile(join(dir, 'policies', 'code-of-conduct.md'), '# CoC\n', 'utf8');
+    await mkdir(join(dir, 'keys'), { recursive: true });
+    await writeFile(join(dir, 'keys', 'notes-about-keys.md'), '# not secret\n', 'utf8');
+
+    await fn(dir);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The happy path
+// ---------------------------------------------------------------------------
+
+test('a workspace written by writeBundleFolder satisfies the invariants', async () => {
+  await makeWorkspace(async dir => {
+    assert.deepEqual(await checkWorkspaceInvariants(dir), []);
+    await assert.doesNotReject(assertWorkspaceInvariants(dir));
+  });
+});
+
+test('a plain cp -R of a workspace is still a valid workspace (invariant 5)', async () => {
+  await makeWorkspace(async dir => {
+    const copy = `${dir}-copy`;
+    // fs.cp is what a backup tool or Finder drag does: bytes, no app.
+    const { cp } = await import('fs/promises');
+    await cp(dir, copy, { recursive: true });
+    assert.deepEqual(await checkWorkspaceInvariants(copy), []);
+  });
+});
+
+test('a legitimate keys/ folder in the working tree is not flagged', async () => {
+  // The distinction the seed fix turned on: only `.workspace/keys` is private
+  // key state. Matching on basename would break a user's own folder.
+  await makeWorkspace(async dir => {
+    const violations = await checkWorkspaceInvariants(dir);
+    assert.equal(violations.length, 0, JSON.stringify(violations));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The violations — a checker that never fires is worth nothing
+// ---------------------------------------------------------------------------
+
+test('REGRESSION #233: a seeded .workspace/keys/ is caught', async () => {
+  await makeWorkspace(async dir => {
+    // Exactly what the mobile seed produced: another peer's identity, copied.
+    await mkdir(join(dir, '.workspace', 'keys'), { recursive: true });
+    await writeFile(
+      join(dir, '.workspace', 'keys', 'identity.json'),
+      '{"secret":"…"}\n',
+      'utf8',
+    );
+
+    const violations = await checkWorkspaceInvariants(dir);
+    assert.equal(violations.length, 1, JSON.stringify(violations));
+    assert.equal(violations[0]!.invariant, 6);
+    assert.match(violations[0]!.path, /\.workspace[/\\]keys$/);
+    await assert.rejects(assertWorkspaceInvariants(dir), /invariant 6/);
+  });
+});
+
+test('metadata scattered outside .workspace/ is caught (invariant 1)', async () => {
+  await makeWorkspace(async dir => {
+    await writeFile(join(dir, '.workspace-state'), 'stray\n', 'utf8');
+    const violations = await checkWorkspaceInvariants(dir);
+    assert.equal(violations.length, 1, JSON.stringify(violations));
+    assert.equal(violations[0]!.invariant, 1);
+  });
+});
+
+test('a mutable lock file is caught (invariant 4)', async () => {
+  await makeWorkspace(async dir => {
+    // The thing that cannot survive a Dropbox conflicted-copy race.
+    await writeFile(join(dir, '.workspace', 'store.lock'), '', 'utf8');
+    const violations = await checkWorkspaceInvariants(dir);
+    assert.ok(violations.some(v => v.invariant === 4), JSON.stringify(violations));
+  });
+});
+
+test('an unrecognised entry in .workspace/ is caught (invariant 1)', async () => {
+  await makeWorkspace(async dir => {
+    await writeFile(join(dir, '.workspace', 'scratch.json'), '{}\n', 'utf8');
+    const violations = await checkWorkspaceInvariants(dir);
+    assert.ok(
+      violations.some(v => v.invariant === 1 && v.path.includes('scratch.json')),
+      JSON.stringify(violations),
+    );
+  });
+});
+
+test('a missing manifest is caught', async () => {
+  await makeWorkspace(async dir => {
+    await rm(join(dir, '.workspace', 'manifest.json'));
+    const violations = await checkWorkspaceInvariants(dir);
+    assert.ok(violations.some(v => v.message.includes('manifest.json')));
+  });
+});
+
+test('a corrupt manifest is caught rather than crashing the check', async () => {
+  await makeWorkspace(async dir => {
+    await writeFile(join(dir, '.workspace', 'manifest.json'), 'not json', 'utf8');
+    const violations = await checkWorkspaceInvariants(dir);
+    assert.ok(violations.some(v => v.invariant === 5), JSON.stringify(violations));
+  });
+});
+
+test('a tree with no .workspace/ is not a workspace', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'ws-conformance-bare-'));
+  try {
+    await writeFile(join(base, 'a.md'), '# hi\n', 'utf8');
+    const violations = await checkWorkspaceInvariants(base);
+    assert.ok(violations.some(v => v.invariant === 1));
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Export mode — the other half of invariant 6
+// ---------------------------------------------------------------------------
+
+test('an export that still carries .workspace/ is caught (invariant 6)', async () => {
+  await makeWorkspace(async dir => {
+    const violations = await checkWorkspaceInvariants(dir, { export: true });
+    assert.ok(violations.some(v => v.invariant === 6), JSON.stringify(violations));
+  });
+});
+
+test('a true plaintext export passes in export mode', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'ws-conformance-export-'));
+  try {
+    await mkdir(join(base, 'policies'), { recursive: true });
+    await writeFile(join(base, 'policies', 'coc.md'), '# CoC\n', 'utf8');
+    assert.deepEqual(await checkWorkspaceInvariants(base, { export: true }), []);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('REGRESSION #249: a manifest naming logs without transport dirs is a stub, and caught', async () => {
+  await makeWorkspace(async dir => {
+    // Graft log keys into the manifest without creating store/v1/ dirs —
+    // exactly the shape a pre-ADR-0003 workspace left on disk.
+    const manifestPath = join(dir, '.workspace', 'manifest.json');
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as Record<string, unknown>;
+    manifest.logs = { data: 'a'.repeat(64), keyDelivery: 'b'.repeat(64) };
+    await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
+
+    const violations = await checkWorkspaceInvariants(dir);
+    assert.equal(violations.filter(v => v.invariant === 5).length, 2, JSON.stringify(violations));
+
+    // And with the dirs present, clean again.
+    await mkdir(join(dir, '.workspace', 'store', 'v1', 'a'.repeat(64)), { recursive: true });
+    await mkdir(join(dir, '.workspace', 'store', 'v1', 'b'.repeat(64)), { recursive: true });
+    assert.deepEqual(await checkWorkspaceInvariants(dir), []);
+  });
+});

--- a/packages/portable-bootstrap/tsconfig.json
+++ b/packages/portable-bootstrap/tsconfig.json
@@ -2,9 +2,15 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "allowImportingTsExtensions": true,
     "noEmit": true
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": [
+    "src/**/*",
+    "tests/**/*",
+    "../p2p-runtime/src/*.d.ts"
+  ]
 }

--- a/packages/ucan-boundary/tsconfig.json
+++ b/packages/ucan-boundary/tsconfig.json
@@ -2,9 +2,15 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "allowImportingTsExtensions": true,
     "noEmit": true
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": [
+    "src/**/*",
+    "tests/**/*",
+    "../p2p-runtime/src/*.d.ts"
+  ]
 }

--- a/packages/workspace/src/blobs.ts
+++ b/packages/workspace/src/blobs.ts
@@ -1,0 +1,191 @@
+// Binary content for a workspace.
+//
+// `workspace-format.md`: "Unknown file types are recorded as opaque blobs and
+// sync to peers byte-for-byte." Until now the document log could carry only
+// strings, so a canvas synced to a peer without its images and rendered the
+// broken-image placeholder — which the renderer does faithfully (#234).
+//
+// ## Why blobs get their own log
+//
+// This was the open question in #234, and the code answers it. `entries()`
+// fetches, decrypts and returns EVERY block in the data log, and the store
+// calls it on every `change` event. Put a 10 MB image in that log and every
+// refresh on every peer becomes 10 MB of fetch-and-decrypt, forever.
+//
+// So blob bytes go in a separate log named in `manifest.logs` — which is a
+// map precisely so a workspace can name more than one — and the data log
+// keeps only small references. Fetching a blob is then something the app
+// chooses to do, rather than something every peer pays for on every change.
+//
+// ## Why not Hyperblobs
+//
+// It is the ecosystem's purpose-built answer and it was the first thing
+// checked. It wants a raw Hypercore, whereas every log here is wrapped by
+// `encryptedLog` — composition over the `Log` interface, which is what gives
+// tier-gated content its encryption. Using Hyperblobs would mean handing it
+// the unwrapped core and writing blob bytes in the clear, or reimplementing
+// the sealing inside it. Chunking over the existing `Log` is both smaller
+// than that and keeps encryption a property of the abstraction rather than
+// something each caller remembers.
+//
+// ## Format
+//
+// A blob is split into fixed-size chunks, each appended as one block. The
+// reference returned carries the chunk indices, so reading is direct — no
+// scan, no index block, no lookup table. The reference is what the document
+// log stores, and it is small regardless of blob size.
+
+import { sha256Hex } from '@workspace.sh/p2p-runtime';
+import type { Log } from '@workspace.sh/p2p-runtime';
+
+/**
+ * 64 KiB. Small enough that a partial fetch is cheap and a chunk fits
+ * comfortably in a Hypercore block after seal overhead; large enough that a
+ * typical image is a handful of blocks rather than hundreds.
+ */
+export const CHUNK_BYTES = 64 * 1024;
+
+/**
+ * 64 MiB. A cap exists because a Hypercore log is the wrong home for a video
+ * — every byte replicates to every peer that fetches the blob, and there is
+ * no partial-file streaming here. Chosen to comfortably clear the images and
+ * PDFs a workspace actually contains while refusing the case that would make
+ * sync unusable. Raise it when there is a reason, not by default.
+ */
+export const MAX_BLOB_BYTES = 64 * 1024 * 1024;
+
+/**
+ * A pointer to blob content, small enough to live in a document entry.
+ *
+ * `id` is the SHA-256 of the content, hex-encoded. Content addressing gives
+ * integrity checking (verified on read) and makes deduplication possible
+ * without a format change.
+ */
+export interface BlobRef {
+  /** Format version for the reference itself. */
+  v: 1;
+  /** SHA-256 of the content, hex. */
+  id: string;
+  /** Byte length of the content. */
+  size: number;
+  /** Indices of this blob's chunks in the blob log, in order. */
+  chunks: number[];
+  /**
+   * Media type, when the writer knows it. Advisory: it tells a viewer how to
+   * render without sniffing, and is not trusted for anything security-bearing.
+   */
+  contentType?: string;
+}
+
+export class BlobSizeError extends Error {
+  constructor(size: number) {
+    super(
+      `file is ${formatBytes(size)}, which is over the ${formatBytes(MAX_BLOB_BYTES)} limit ` +
+        `for workspace content — every peer downloads it in full, so large media ` +
+        `should be linked rather than embedded`,
+    );
+    this.name = 'BlobSizeError';
+  }
+}
+
+export class BlobIntegrityError extends Error {
+  constructor(expected: string, actual: string) {
+    super(`blob content does not match its hash (expected ${expected}, got ${actual})`);
+    this.name = 'BlobIntegrityError';
+  }
+}
+
+/** Human-readable byte size, for messages a user will read. */
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${Math.round(n / 1024)} KB`;
+  return `${Math.round((n / (1024 * 1024)) * 10) / 10} MB`;
+}
+
+/**
+ * Append `content` to `log` as chunks and return a reference to it.
+ *
+ * `seen` is an optional content-hash → reference cache. Passing one
+ * deduplicates repeat writes of identical content — the same image dropped
+ * into three canvases costs one copy. It is per-instance and therefore
+ * per-session; durable deduplication needs an index of what the log already
+ * holds, which is a separate piece of work and needs no format change,
+ * because the hash is already in the reference.
+ */
+export async function writeBlob(
+  log: Log,
+  content: Uint8Array,
+  options: {contentType?: string; seen?: Map<string, BlobRef>} = {},
+): Promise<BlobRef> {
+  if (content.byteLength > MAX_BLOB_BYTES) throw new BlobSizeError(content.byteLength);
+
+  const id = sha256Hex(content);
+  const cached = options.seen?.get(id);
+  if (cached) return cached;
+
+  const chunks: number[] = [];
+  // A zero-length blob writes no chunks; `chunks: []` round-trips correctly
+  // and costs nothing, which beats special-casing empty files at every reader.
+  for (let offset = 0; offset < content.byteLength; offset += CHUNK_BYTES) {
+    const end = Math.min(offset + CHUNK_BYTES, content.byteLength);
+    // `subarray` shares memory rather than copying; the log serialises the
+    // bytes on append, so no copy is needed here.
+    chunks.push(await log.append(content.subarray(offset, end)) - 1);
+  }
+
+  const ref: BlobRef = {
+    v: 1,
+    id,
+    size: content.byteLength,
+    chunks,
+    ...(options.contentType === undefined ? {} : {contentType: options.contentType}),
+  };
+  options.seen?.set(id, ref);
+  return ref;
+}
+
+/**
+ * Read the content a reference points at.
+ *
+ * Verifies the content against the reference's hash and throws on a mismatch.
+ * The bytes arrive from a peer, so "these are the bytes that were written" is
+ * a claim worth checking rather than assuming — and content addressing makes
+ * the check free.
+ */
+export async function readBlob(log: Log, ref: BlobRef): Promise<Uint8Array> {
+  const out = new Uint8Array(ref.size);
+  let offset = 0;
+  for (const index of ref.chunks) {
+    const chunk = await log.get(index);
+    if (offset + chunk.byteLength > ref.size) {
+      // A chunk longer than the reference claims means the reference and the
+      // log disagree; truncating silently would hand back plausible garbage.
+      throw new BlobIntegrityError(ref.id, 'content longer than declared size');
+    }
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  if (offset !== ref.size) {
+    throw new BlobIntegrityError(ref.id, `content shorter than declared size (${offset}/${ref.size})`);
+  }
+
+  const actual = sha256Hex(out);
+  if (actual !== ref.id) throw new BlobIntegrityError(ref.id, actual);
+  return out;
+}
+
+/** Whether `value` is a well-formed blob reference. */
+export function isBlobRef(value: unknown): value is BlobRef {
+  if (typeof value !== 'object' || value === null) return false;
+  const r = value as Record<string, unknown>;
+  return (
+    r.v === 1 &&
+    typeof r.id === 'string' &&
+    r.id.length > 0 &&
+    typeof r.size === 'number' &&
+    Number.isFinite(r.size) &&
+    r.size >= 0 &&
+    Array.isArray(r.chunks) &&
+    r.chunks.every(c => typeof c === 'number' && Number.isInteger(c) && c >= 0)
+  );
+}

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -21,7 +21,24 @@
 // internals): Autobase multi-writer (#11), the document/section model, and
 // `workspace://` join.
 
-import { createHash } from 'node:crypto';
+// SHA-256 via sodium rather than `node:crypto`, so this module packs into a
+// Bare worklet for the mobile path (#229). Byte-identical output — verified
+// against createHash('sha256') — so topic IDs are unchanged.
+import b4a from 'b4a';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import sodiumModule from 'sodium-universal';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sodium = sodiumModule as any;
+
+import { readBlob, writeBlob, type BlobRef } from './blobs.ts';
+import {
+  listWorkingTree,
+  watchWorkingTree,
+  type ListOptions,
+  type WorkingTreeChange,
+  type WorkingTreeEntry,
+} from './watcher.ts';
 
 import {
   encryptedLog,
@@ -57,9 +74,33 @@ export interface WorkspaceCreateOptions {
   folder: string;
   /** Friendly name (metadata only, for now). */
   name?: string;
-  /** 32-byte seed fixing the workspace root identity. Defaults to random. */
+  /**
+   * 32-byte seed fixing the WORKSPACE's root identity. Defaults to random.
+   *
+   * One workspace, one root keypair — `workspace-format.md` resolves this
+   * explicitly: "Orgs with multiple workspaces create multiple `.workspace`
+   * folders, each with its own root keypair." The root public key IS the
+   * workspaceId, and the swarm topic is a hash of it, so sharing a root seed
+   * between workspaces gives them one identity and one topic.
+   *
+   * Pass this only to make a workspace reproducible in a test. Never pass a
+   * device's identity seed: that is a different identity (see `identitySeed`).
+   */
   rootSeed?: Uint8Array;
-  /** Corestore storage path. Defaults to `<folder>/.workspace/store`. */
+  /**
+   * 32-byte seed for the CREATOR's own peer identity — this device.
+   *
+   * Distinct from `rootSeed` by design. `identity-recovery.md`: "A device's
+   * identity is an ed25519 keypair whose public half is its `did:key`; the
+   * private half never leaves the device." The root identity belongs to the
+   * workspace; this one belongs to the machine, and one machine can create
+   * many workspaces.
+   *
+   * Defaults to `rootSeed`, which is the pre-#317 behaviour and is what the
+   * tests rely on. Real callers should pass their device seed.
+   */
+  identitySeed?: Uint8Array;
+  /** Working-store path (app-private). Unset → the runtime's temp default. */
   storage?: string;
   /** DHT bootstrap nodes (omit for the public DHT). */
   bootstrap?: Bootstrap;
@@ -71,7 +112,7 @@ export interface WorkspaceOpenOptions {
   folder: string;
   /** This peer's 32-byte identity seed. An envelope for its DID must exist. */
   identitySeed: Uint8Array;
-  /** Corestore storage path. Defaults to `<folder>/.workspace/store`. */
+  /** Working-store path (app-private). Unset → the runtime's temp default. */
   storage?: string;
   bootstrap?: Bootstrap;
 }
@@ -83,19 +124,70 @@ const CAP: (resource: string) => CapabilityDescriptor = (resource) => ({
   with: resource,
 });
 
+/**
+ * How long a workspace must be quiet before its log is copied into the folder.
+ *
+ * Long enough that a burst of edits costs one flush, short enough that the
+ * folder is never far behind. The materialiser debounces disk writes on a
+ * similar scale for the same reason.
+ */
+const FLUSH_DEBOUNCE_MS = 2_000;
+
 /** Derive the swarm topic deterministically from the workspaceId. */
 function topicForWorkspace(workspaceId: string): string {
-  return createHash('sha256').update(`workspace://${workspaceId}`).digest('hex');
+  const out = b4a.alloc(sodium.crypto_hash_sha256_BYTES);
+  sodium.crypto_hash_sha256(out, b4a.from(`workspace://${workspaceId}`));
+  return b4a.toString(out, 'hex');
 }
 
-function defaultStorage(folder: string): string {
-  return `${folder}/.workspace/store`;
+/** Transport-form directory for one log (workspace-format.md § store/). */
+function transportDir(folder: string, key: string): string {
+  return `${folder}/.workspace/store/v1/${key}`;
 }
 
 /**
  * A live workspace handle. Obtain one via `Workspace.create` or
  * `Workspace.open`; release it with `close()`.
  */
+
+/**
+ * Announce this workspace on the swarm — WITHOUT waiting for it.
+ *
+ * Measured on a cellular connection: opening the corestore takes 73 ms and
+ * flushing the DHT announce takes **40 seconds**. Awaiting the announce before
+ * returning a workspace made every local operation wait on a network round
+ * trip, which is not what local-first means. The logs are open and readable
+ * long before the announce lands; peers arrive when they arrive.
+ *
+ * See the spike repo's `docs/network-conditions.md` for the measurements and
+ * for why a resolved `joinTopic` does not currently prove the announce
+ * succeeded.
+ *
+ * The returned promise is handed to the caller AND observed here, so a failed
+ * announce can be inspected without ever becoming an unhandled rejection.
+ * Attaching a handler is what marks it observed — a caller that ignores it is
+ * therefore safe.
+ */
+function announceInBackground(runtime: P2PRuntime, topic: string): Promise<void> {
+  // `swarm: false` runtimes are local-only and joining would throw. Nothing
+  // else — logs, flush, hydrate, the folder on disk — is affected; the
+  // workspace simply has no peers.
+  if (runtime.replicates === false) return Promise.resolve();
+
+  const announced = runtime.joinTopic(topic);
+  announced.catch((e: unknown) => {
+    // Terminal-visible, because a workspace that silently never announces
+    // looks exactly like one with no peers nearby.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[workspace] announce failed for ${topic.slice(0, 8)}…: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    );
+  });
+  return announced;
+}
+
 export class Workspace {
   /** Stable workspace identifier — the root public key, hex. */
   readonly id: string;
@@ -111,11 +203,28 @@ export class Workspace {
   private readonly folder: string;
   private readonly dataLog: Log; // K0_org-encrypted view
   private readonly keyDeliveryLog: Log;
+  /** Binary content, K0_org-encrypted. Null on a pre-blob workspace. */
+  private readonly blobLog: Log | null;
+  /** Per-session content-hash cache, so one image written twice costs one copy. */
+  private readonly blobsSeen = new Map<string, BlobRef>();
   // Root principal + secret are present only for the admin (creator); a
   // plain member opens without them and therefore cannot invite.
   private readonly root: Principal | null;
   private readonly listeners = new Set<ChangeListener>();
+  /** Pending debounced flush, if a write has scheduled one. */
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Set once close() has run, so a late timer cannot write to a closed log. */
+  private closed = false;
+  /**
+   * Resolves once the swarm announce has landed; rejects if it failed.
+   *
+   * Nothing needs to await this to use the workspace — that is the point. It
+   * exists so a caller that genuinely wants to know (a test, or a UI showing
+   * "local only" versus "syncing") can ask, rather than guessing from silence.
+   */
+  readonly announced: Promise<void>;
   private offChange: (() => void) | null = null;
+  private stopWatching: (() => void) | null = null;
 
   private constructor(args: {
     runtime: P2PRuntime;
@@ -127,7 +236,9 @@ export class Workspace {
     folder: string;
     dataLog: Log;
     keyDeliveryLog: Log;
+    blobLog: Log | null;
     root: Principal | null;
+    announced: Promise<void>;
   }) {
     this.runtime = args.runtime;
     this.id = args.id;
@@ -138,7 +249,9 @@ export class Workspace {
     this.folder = args.folder;
     this.dataLog = args.dataLog;
     this.keyDeliveryLog = args.keyDeliveryLog;
+    this.blobLog = args.blobLog;
     this.root = args.root;
+    this.announced = args.announced;
 
     // Fan the underlying log's append event out to registered listeners.
     this.offChange = this.dataLog.on('append', () => {
@@ -157,6 +270,10 @@ export class Workspace {
 
   static async create(opts: WorkspaceCreateOptions): Promise<Workspace> {
     const rootSeed = opts.rootSeed ?? randomSeed();
+    // The creator's peer identity, which is NOT the workspace's root identity.
+    // Defaults to the root seed so existing callers and tests are unchanged.
+    const identitySeed = opts.identitySeed ?? rootSeed;
+    const selfDid = didFromSeed(identitySeed);
     const root = await principalFromSeed(rootSeed);
     const rootKp = keyPairFromSeed(rootSeed);
     const rootSecretKey = rootKp.secretKey; // 64-byte sodium form
@@ -168,16 +285,37 @@ export class Workspace {
     // it via a sealed envelope.
     const k0 = randomBytes32();
 
-    // Build the admin's own membership proof (root self-delegation) up front —
-    // it's derivable from the seed, so the auth gate can be wired at runtime
-    // construction. The creator's peer identity IS the root identity in v1.
-    const localProof = (
-      await createEnvelope({ did: rootDid, resource, key: k0, capability: CAP(resource) }, root)
-    ).ucan;
+    // The creator's own envelope. Built up front because the auth gate needs
+    // the membership proof at runtime-construction time, and KEPT because
+    // `open` recovers K0_org from exactly this envelope.
+    //
+    // It used to be built here, have its `.ucan` taken, and be discarded — so
+    // the folder was written with no envelopes at all and the creator could
+    // never reopen their own workspace. The creator's peer identity IS the
+    // root identity in v1, but being root is not what `open` checks: it looks
+    // for an envelope addressed to the opening DID, exactly as it does for
+    // anyone else.
+    //
+    // Addressed to the CREATOR'S DEVICE, not to the root. Root issuing a
+    // capability to a device is precisely the delegation `identity-recovery.md`
+    // describes ("root → device, scoped + expiring"), and it is what lets the
+    // two identities differ at all: `open` looks for an envelope addressed to
+    // the opening device, so addressing it to the root only worked while the
+    // two seeds were the same value (#317).
+    const selfEnvelope = await createEnvelope(
+      { did: selfDid, resource, key: k0, capability: CAP(resource) },
+      root,
+    );
+    const localProof = selfEnvelope.ucan;
 
     const runtime = await opts.createRuntime({
-      storage: opts.storage ?? defaultStorage(opts.folder),
-      identitySeed: rootSeed,
+      // No folder-based default: RocksDB must never live inside the
+      // workspace folder (ADR 0003). Unset falls through to the runtime's
+      // own default, a private temp directory.
+      storage: opts.storage,
+      // The device's identity on the swarm — the root keypair is the
+      // workspace's identity and is not a peer.
+      identitySeed,
       ...(opts.bootstrap ? { bootstrap: opts.bootstrap } : {}),
       auth: {
         localProof,
@@ -188,9 +326,13 @@ export class Workspace {
       },
     });
 
-    // Well-known logs: a primary data log + the live key delivery log.
+    // Well-known logs: a primary data log, the live key delivery log, and a
+    // separate log for binary content. Blobs are kept out of the data log
+    // because `entries()` reads that log in full on every change — see
+    // ./blobs.ts.
     const rawDataLog = await runtime.createLog();
     const keyDeliveryLog = await runtime.createLog();
+    const rawBlobLog = await runtime.createLog();
 
     // Persist the bundle (manifest + attestation + log keys) to the folder.
     const bundle = await createBundle({
@@ -198,24 +340,37 @@ export class Workspace {
       root,
       rootSecretKey,
       recipients: [],
-      logs: { data: rawDataLog.key, keyDelivery: keyDeliveryLog.key },
+      logs: {
+        data: rawDataLog.key,
+        keyDelivery: keyDeliveryLog.key,
+        blobs: rawBlobLog.key,
+      },
     });
+    // Same push `invite` uses — the creator is a member of their own
+    // workspace, and is recorded the same way every other member is.
+    bundle.envelopes.push(selfEnvelope);
     await writeBundleFolder(bundle, opts.folder);
 
-    await runtime.joinTopic(topicForWorkspace(workspaceId));
+    const announced = announceInBackground(runtime, topicForWorkspace(workspaceId));
 
-    return new Workspace({
+    const ws = new Workspace({
       runtime,
+      announced,
       id: workspaceId,
-      did: rootDid,
+      did: selfDid,
       rootDid,
       k0,
       resource,
       folder: opts.folder,
       dataLog: encryptedLog(rawDataLog, k0),
       keyDeliveryLog,
+      blobLog: encryptedLog(rawBlobLog, k0),
       root,
     });
+    // Materialise the (empty) transport dirs now: a created folder has the
+    // full on-disk shape from its first second, not only after a first flush.
+    await ws.flushStore();
+    return ws;
   }
 
   // -------------------------------------------------------------------------
@@ -249,7 +404,10 @@ export class Workspace {
     const localProof = myEnvelope.ucan;
 
     const runtime = await opts.createRuntime({
-      storage: opts.storage ?? defaultStorage(opts.folder),
+      // No folder-based default: RocksDB must never live inside the
+      // workspace folder (ADR 0003). Unset falls through to the runtime's
+      // own default, a private temp directory.
+      storage: opts.storage,
       identitySeed: opts.identitySeed,
       ...(opts.bootstrap ? { bootstrap: opts.bootstrap } : {}),
       auth: {
@@ -261,13 +419,36 @@ export class Workspace {
       },
     });
 
+    // Hydrate the working store from the folder's transport form FIRST —
+    // this is what makes a plain-copied folder open on a device that has
+    // never met the writer (invariant 5). Tolerant per log: a folder with no
+    // store, or a torn tail, hydrates what it can; replication heals the
+    // rest.
+    if (runtime.hydrateLogFromDir) {
+      const keys = [manifest.logs.data, manifest.logs.keyDelivery, manifest.logs.blobs];
+      for (const key of keys) {
+        if (!key) continue;
+        try {
+          await runtime.hydrateLogFromDir(key, transportDir(opts.folder, key));
+        } catch {
+          /* hydration is best-effort by design */
+        }
+      }
+    }
+
     const rawDataLog = await runtime.openLog(manifest.logs.data);
     const keyDeliveryLog = await runtime.openLog(manifest.logs.keyDelivery);
+    // Absent on a workspace created before blob support. Opening still works;
+    // only writing a blob fails, and it says why.
+    const rawBlobLog = manifest.logs.blobs
+      ? await runtime.openLog(manifest.logs.blobs)
+      : null;
 
-    await runtime.joinTopic(topicForWorkspace(workspaceId));
+    const announced = announceInBackground(runtime, topicForWorkspace(workspaceId));
 
     return new Workspace({
       runtime,
+      announced,
       id: workspaceId,
       did: selfDid,
       rootDid,
@@ -276,6 +457,7 @@ export class Workspace {
       folder: opts.folder,
       dataLog: encryptedLog(rawDataLog, k0),
       keyDeliveryLog,
+      blobLog: rawBlobLog === null ? null : encryptedLog(rawBlobLog, k0),
       root: null,
     });
   }
@@ -313,15 +495,100 @@ export class Workspace {
   /** Append an entry to the workspace's data log (sealed under K0_org). */
   async write(entry: Uint8Array): Promise<void> {
     await this.dataLog.append(entry);
+    this.scheduleFlush();
+  }
+
+  /**
+   * Write the log's portable copy into the folder, shortly after a write.
+   *
+   * The transport form under `.workspace/store/v1/` is what makes the folder
+   * self-contained — invariant 5: a `cp -R` must produce a valid workspace.
+   * It used to be written only by `close()`, and nothing closes a workspace:
+   * quitting terminates the child, and since workspaces became live by default
+   * they are not closed at all. Folders were left with a manifest and no log,
+   * which opens as a workspace with no documents rather than failing (#341).
+   *
+   * Debounced rather than written per append. A flush replicates the whole log
+   * into a capture replica, so doing it per keystroke would be wasteful; a
+   * couple of seconds of quiet means the folder trails the log by seconds
+   * instead of by a session.
+   *
+   * Failures are swallowed for the same reason `close()` swallows them: a
+   * read-only or full folder must not break writing. The difference is that
+   * the next write schedules another attempt, so a transient failure heals
+   * rather than persisting until close.
+   */
+  private scheduleFlush(): void {
+    if (this.closed) return;
+    if (!this.runtime.flushLogToDir) return;
+    if (this.flushTimer !== null) clearTimeout(this.flushTimer);
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      if (this.closed) return;
+      void this.flushStore().catch(() => {
+        // See above: the working store still holds everything, and the next
+        // write tries again.
+      });
+    }, FLUSH_DEBOUNCE_MS);
+    // Never hold the process open for a flush. Node and Bare both honour
+    // unref; a host without it simply keeps its usual timer semantics.
+    (this.flushTimer as unknown as { unref?: () => void }).unref?.();
   }
 
   /** Read all entries, decrypted. */
   async entries(): Promise<Uint8Array[]> {
+    // How far to read depends on whether a block could still arrive.
+    //
+    // A replicating peer MUST wait: hypercore cores are sparse, so a freshly
+    // announced block is known-of before it is held, and `get()` fetching it
+    // is the whole mechanism by which sync delivers anything. Stopping at the
+    // downloaded prefix there would report an empty workspace whenever the
+    // read raced the transfer.
+    //
+    // A local-only log must NOT wait: nobody can ever supply the block, so
+    // `get()` past the verified prefix never returns. That is the shape a
+    // folder with a corrupt or missing transport message hydrates into — and
+    // stopping is also the right ANSWER, not merely the terminating one,
+    // since a tail that failed verification must not fold in.
+    const canReceive = this.runtime.replicates !== false;
+    const readable = canReceive
+      ? this.dataLog.length
+      : (this.dataLog.contiguousLength ?? this.dataLog.length);
     const out: Uint8Array[] = [];
-    for (let i = 0; i < this.dataLog.length; i++) {
+    for (let i = 0; i < readable; i++) {
       out.push(await this.dataLog.get(i));
     }
     return out;
+  }
+
+  /**
+   * Store binary content and return a reference small enough to put in a
+   * document entry. The bytes go to the blob log, not the data log.
+   */
+  async writeBlob(
+    content: Uint8Array,
+    options: { contentType?: string } = {},
+  ): Promise<BlobRef> {
+    if (this.blobLog === null) {
+      throw new Error(
+        'this workspace has no blob log — it was created before binary content ' +
+          'was supported, so images and other files cannot be stored in it',
+      );
+    }
+    return writeBlob(this.blobLog, content, { ...options, seen: this.blobsSeen });
+  }
+
+  /** Fetch the content a reference points at, verifying it against its hash. */
+  async readBlob(ref: BlobRef): Promise<Uint8Array> {
+    if (this.blobLog === null) {
+      throw new Error('this workspace has no blob log — nothing to read from');
+    }
+    return readBlob(this.blobLog, ref);
+  }
+
+  /** Whether this workspace can store binary content. */
+  get supportsBlobs(): boolean {
+    return this.blobLog !== null;
   }
 
   /** Number of entries currently visible locally. */
@@ -340,12 +607,75 @@ export class Workspace {
   // Lifecycle
   // -------------------------------------------------------------------------
 
+  /**
+   * Watch the working tree and report settled external changes.
+   *
+   * Reports raw bytes per path; it deliberately does not encode document
+   * entries, because the log is a byte log and the document model belongs to
+   * the consumer (`@workspace.sh/core`). Returns a stop function.
+   *
+   * NOTE for callers: this fires for OUR OWN writes too — the filesystem
+   * cannot tell them apart. Whoever materialises the log to disk must filter
+   * echoes before writing back, or the log grows without bound.
+   */
+  watchWorkingTree(onChange: (change: WorkingTreeChange) => void): () => void {
+    const stop = watchWorkingTree(this.folder, onChange);
+    this.stopWatching = stop;
+    return stop;
+  }
+
+  /**
+   * Read every watchable file in the working tree, once.
+   *
+   * The counterpart to `watchWorkingTree`, which reports only *changes* and so
+   * can never see a file that merely exists. Without this, divergence that
+   * happened while the workspace was closed is invisible, and the materialise
+   * pass writes the log over it (#280).
+   */
+  listWorkingTree(options?: ListOptions): Promise<WorkingTreeEntry[]> {
+    return listWorkingTree(this.folder, options);
+  }
+
+  /**
+   * Flush every log to its transport form in `.workspace/store/v1/` —
+   * what makes the folder a complete, portable copy (ADR 0003). Called
+   * automatically on close; call it explicitly before sharing the folder.
+   *
+   * No-op (returning null) on a runtime that does not own a corestore.
+   */
+  async flushStore(): Promise<{ written: number } | null> {
+    if (!this.runtime.flushLogToDir) return null;
+    let written = 0;
+    for (const log of [this.dataLog, this.keyDeliveryLog, this.blobLog]) {
+      if (log === null) continue;
+      const r = await this.runtime.flushLogToDir(log.key, transportDir(this.folder, log.key));
+      written += r.written;
+    }
+    return { written };
+  }
+
   async close(): Promise<void> {
+    if (this.stopWatching) {
+      this.stopWatching();
+      this.stopWatching = null;
+    }
     if (this.offChange) {
       this.offChange();
       this.offChange = null;
     }
     this.listeners.clear();
+    this.closed = true;
+    if (this.flushTimer !== null) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    try {
+      await this.flushStore();
+    } catch {
+      // Flush is durability icing, not correctness: the working store and
+      // any replicated peers still hold everything. Close must not fail
+      // because the folder was read-only or full.
+    }
     await this.runtime.close();
   }
 }
@@ -369,3 +699,25 @@ function toHex(bytes: Uint8Array): string {
   for (const b of bytes) s += b.toString(16).padStart(2, '0');
   return s;
 }
+
+export {
+  BlobIntegrityError,
+  BlobSizeError,
+  CHUNK_BYTES,
+  isBlobRef,
+  MAX_BLOB_BYTES,
+  readBlob,
+  writeBlob,
+  type BlobRef,
+} from './blobs.ts';
+
+export {
+  isWatchablePath,
+  listWorkingTree,
+  toWorkspaceRelative,
+  watchWorkingTree,
+  type ListOptions,
+  type WatchOptions,
+  type WorkingTreeChange,
+  type WorkingTreeEntry,
+} from './watcher.ts';

--- a/packages/workspace/src/ipc/child-bin.ts
+++ b/packages/workspace/src/ipc/child-bin.ts
@@ -1,0 +1,34 @@
+// Entry point for the spawned Workspace child process.
+//
+//   node --experimental-strip-types --no-warnings <path-to-this-file>
+//
+// stdin/stdout carry JSON-RPC (see ./protocol.ts); stderr is free-form logs.
+// Same shape as @workspace.sh/p2p-runtime's own child-bin.ts, one level up
+// the stack (Workspace operations instead of raw Log operations).
+
+import { WorkspaceChild } from './child.ts';
+
+const child = new WorkspaceChild((s) => {
+  process.stdout.write(s);
+});
+
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk: string) => {
+  child.feed(chunk).catch((err) => {
+    process.stderr.write(`[ws-child] feed crashed: ${(err as Error).stack ?? err}\n`);
+  });
+});
+
+process.stdin.on('end', () => {
+  // Parent closed the pipe. Exit cleanly so we don't linger.
+  process.exit(0);
+});
+
+process.on('uncaughtException', (err) => {
+  process.stderr.write(`[ws-child] uncaughtException: ${err.stack ?? err}\n`);
+  process.exit(1);
+});
+process.on('unhandledRejection', (err) => {
+  process.stderr.write(`[ws-child] unhandledRejection: ${(err as Error).stack ?? err}\n`);
+  process.exit(1);
+});

--- a/packages/workspace/src/ipc/child.ts
+++ b/packages/workspace/src/ipc/child.ts
@@ -1,0 +1,206 @@
+// WorkspaceChild — hosts one or more live Workspace instances, dispatching
+// the wire protocol in ./protocol.ts. Mirrors @workspace.sh/p2p-runtime's
+// own Child class (same wire shape: line-delimited JSON, id-correlated
+// request/response, unsolicited events) but for Workspace-level operations
+// instead of Log-level ones.
+//
+// Runs inside the spawned Node child process — the ONLY place this package's
+// fs/sodium/ucanto/node:crypto-heavy code actually executes. The RN/Hermes
+// side never imports @workspace.sh/workspace directly; it talks to this
+// class's counterpart on the wire via RemoteWorkspace (./remote.node.ts /
+// ./remote.macos.ts).
+
+import { createRuntime } from '@workspace.sh/p2p-runtime/node';
+// Framing only — NOT the `/ipc` barrel, which re-exports NodeTransport and so
+// drags node:child_process into the Bare worklet graph (#229).
+import { encode, LineDecoder } from '@workspace.sh/p2p-runtime/ipc/framing';
+import { Workspace } from '../index.ts';
+import type { Did } from '@workspace.sh/p2p-runtime';
+import type {
+  ChangeEvent,
+  ChildToParent,
+  Hex,
+  Params,
+  Request,
+  WsCloseResult,
+  WsEntriesResult,
+  WsFlushResult,
+  WsWatchResult,
+  WorkingTreeEvent,
+  WsInfoResult,
+  WsListResult,
+  WsInviteResult,
+  WsWriteResult,
+} from './protocol.ts';
+
+export class WorkspaceChild {
+  private workspaces = new Map<string, Workspace>();
+  /** Active working-tree watchers, by handle. */
+  private watchers = new Map<string, () => void>();
+  private nextHandle = 1;
+  private decoder = new LineDecoder();
+  private write: (s: string) => void;
+
+  constructor(write: (s: string) => void) {
+    this.write = write;
+  }
+
+  /** Feed a chunk read from stdin. Dispatches each complete message. */
+  async feed(chunk: string): Promise<void> {
+    const messages = this.decoder.feed(chunk);
+    for (const m of messages) {
+      await this.handle(m as Request);
+    }
+  }
+
+  private async handle(req: Request): Promise<void> {
+    try {
+      const result = await this.dispatch(req.params);
+      this.send({ id: req.id, ok: true, result });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.send({ id: req.id, ok: false, error: { message } });
+    }
+  }
+
+  private async dispatch(params: Params): Promise<unknown> {
+    switch (params.method) {
+      case 'wsCreate': {
+        const ws = await Workspace.create({
+          createRuntime,
+          folder: params.folder,
+          name: params.name,
+          storage: params.storage,
+          rootSeed: params.rootSeedHex ? hexToBytes(params.rootSeedHex) : undefined,
+          identitySeed: params.identitySeedHex
+            ? hexToBytes(params.identitySeedHex)
+            : undefined,
+          bootstrap: params.bootstrap,
+        });
+        return this.track(ws);
+      }
+      case 'wsOpen': {
+        const ws = await Workspace.open({
+          createRuntime,
+          folder: params.folder,
+          storage: params.storage,
+          identitySeed: hexToBytes(params.identitySeedHex),
+          bootstrap: params.bootstrap,
+        });
+        return this.track(ws);
+      }
+      case 'wsInvite': {
+        const ws = this.require(params.handle);
+        await ws.invite(params.recipientDid as Did);
+        return { ok: true } satisfies WsInviteResult;
+      }
+      case 'wsWrite': {
+        const ws = this.require(params.handle);
+        await ws.write(hexToBytes(params.entryHex));
+        return { ok: true } satisfies WsWriteResult;
+      }
+      case 'wsEntries': {
+        const ws = this.require(params.handle);
+        const entries = await ws.entries();
+        return { entriesHex: entries.map(bytesToHex) } satisfies WsEntriesResult;
+      }
+      case 'wsWatch': {
+        const ws = this.require(params.handle);
+        const handle = params.handle;
+        const existing = this.watchers.get(handle);
+        if (!params.enabled) {
+          if (existing) {
+            existing();
+            this.watchers.delete(handle);
+          }
+          return { watching: false } satisfies WsWatchResult;
+        }
+        if (existing) return { watching: true } satisfies WsWatchResult;
+        this.watchers.set(
+          handle,
+          ws.watchWorkingTree(change => {
+            const evt: WorkingTreeEvent = {
+              event: 'workingTree',
+              handle,
+              path: change.path,
+              bytesHex: change.bytes === null ? null : bytesToHex(change.bytes),
+            };
+            this.send(evt);
+          }),
+        );
+        return { watching: true } satisfies WsWatchResult;
+      }
+      case 'wsList': {
+        const ws = this.require(params.handle);
+        const files = await ws.listWorkingTree(
+          params.extensions ? { extensions: params.extensions } : undefined,
+        );
+        return {
+          files: files.map(f => ({ path: f.path, bytesHex: bytesToHex(f.bytes) })),
+        } satisfies WsListResult;
+      }
+      case 'wsFlush': {
+        const ws = this.require(params.handle);
+        const r = await ws.flushStore();
+        return { written: r === null ? null : r.written } satisfies WsFlushResult;
+      }
+      case 'wsClose': {
+        const ws = this.require(params.handle);
+        const stopWatch = this.watchers.get(params.handle);
+        if (stopWatch) {
+          stopWatch();
+          this.watchers.delete(params.handle);
+        }
+        await ws.close();
+        this.workspaces.delete(params.handle);
+        return { ok: true } satisfies WsCloseResult;
+      }
+    }
+  }
+
+  private track(ws: Workspace): WsInfoResult {
+    const handle = `ws${this.nextHandle++}`;
+    this.workspaces.set(handle, ws);
+    ws.on('change', () => {
+      const evt: ChangeEvent = { event: 'change', handle, length: ws.length };
+      this.send(evt);
+    });
+    return {
+      handle,
+      id: ws.id,
+      did: ws.did,
+      rootDid: ws.rootDid,
+      isAdmin: ws.isAdmin,
+      length: ws.length,
+    };
+  }
+
+  private require(handle: string): Workspace {
+    const ws = this.workspaces.get(handle);
+    if (!ws) throw new Error(`unknown workspace handle: ${handle}`);
+    return ws;
+  }
+
+  private send(msg: ChildToParent): void {
+    this.write(encode(msg));
+  }
+}
+
+// ----- hex helpers ----------------------------------------------------------
+
+function hexToBytes(hex: Hex): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error('odd-length hex');
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
+  return out;
+}
+
+function bytesToHex(b: Uint8Array): Hex {
+  let s = '';
+  for (let i = 0; i < b.length; i++) {
+    s += b[i]!.toString(16).padStart(2, '0');
+  }
+  return s;
+}

--- a/packages/workspace/src/ipc/protocol.ts
+++ b/packages/workspace/src/ipc/protocol.ts
@@ -1,0 +1,136 @@
+// Wire types for the Workspace-level parent <-> child IPC.
+//
+// A distinct, higher-level protocol from @workspace.sh/p2p-runtime's own
+// Log-level IPC (createLog/appendBlock/etc). Reuses that package's transport
+// + framing primitives (@workspace.sh/p2p-runtime/ipc) but speaks its own
+// method registry, because the Workspace facade does real work — fs, sodium,
+// ucanto, node:crypto — that only runs inside the child process; the parent
+// (RN/Hermes) never runs Workspace logic directly, only proxies calls to it.
+//
+// One child process can host multiple open Workspace instances, each
+// identified by an opaque `handle` returned from wsCreate/wsOpen.
+
+export type Hex = string;
+
+export interface Request {
+  id: number;
+  method: Method;
+  params: Params;
+}
+
+export type Response =
+  | { id: number; ok: true; result: unknown }
+  | { id: number; ok: false; error: { message: string } };
+
+export type Event = ChangeEvent | WorkingTreeEvent;
+export interface ChangeEvent {
+  event: 'change';
+  handle: string;
+  length: number;
+}
+
+/**
+ * An external edit to the working tree settled. `bytesHex` is null when the
+ * path no longer exists (deleted, or the temp half of an atomic save).
+ */
+export interface WorkingTreeEvent {
+  event: 'workingTree';
+  handle: string;
+  path: string;
+  bytesHex: Hex | null;
+}
+
+export type ChildToParent = Response | Event;
+export type ParentToChild = Request;
+
+// ----------------------------------------------------------------------------
+// Method registry
+// ----------------------------------------------------------------------------
+
+export type Method =
+  | 'wsCreate'
+  | 'wsOpen'
+  | 'wsInvite'
+  | 'wsWrite'
+  | 'wsEntries'
+  | 'wsFlush'
+  | 'wsWatch'
+  | 'wsList'
+  | 'wsClose';
+
+export interface BootstrapNode {
+  host: string;
+  port: number;
+}
+
+export type Params =
+  | {
+      method: 'wsCreate';
+      folder: string;
+      name?: string;
+      rootSeedHex?: Hex;
+      /**
+       * The CREATOR's device identity — distinct from the workspace's root
+       * identity, which `rootSeedHex` fixes. Optional so an omitted value
+       * falls back to the root seed, preserving the pre-#317 shape for any
+       * caller that has not been updated.
+       */
+      identitySeedHex?: Hex;
+      /** Required — no invariant-4-violating default at this layer. Caller
+       *  (native/app code) must compute an app-container path. */
+      storage: string;
+      /** Private DHT bootstrap nodes. Omit for the public DHT (production). */
+      bootstrap?: BootstrapNode[];
+    }
+  | {
+      method: 'wsOpen';
+      folder: string;
+      identitySeedHex: Hex;
+      storage: string;
+      bootstrap?: BootstrapNode[];
+    }
+  | { method: 'wsInvite'; handle: string; recipientDid: string }
+  | { method: 'wsWrite'; handle: string; entryHex: Hex }
+  | { method: 'wsEntries'; handle: string }
+  | { method: 'wsFlush'; handle: string }
+  | { method: 'wsWatch'; handle: string; enabled: boolean }
+  | { method: 'wsList'; handle: string; extensions?: string[] }
+  | { method: 'wsClose'; handle: string };
+
+// Per-method response result shapes.
+export interface WsInfoResult {
+  handle: string;
+  id: string;
+  did: string;
+  rootDid: string;
+  isAdmin: boolean;
+  length: number;
+}
+export interface WsInviteResult {
+  ok: true;
+}
+export interface WsWriteResult {
+  ok: true;
+}
+export interface WsEntriesResult {
+  entriesHex: Hex[];
+}
+export interface WsWatchResult {
+  watching: boolean;
+}
+/**
+ * One pass over the working tree. Hex-encoded for the same reason entries are:
+ * this protocol is newline-delimited JSON, so bytes cannot travel raw.
+ */
+export interface WsListResult {
+  files: { path: string; bytesHex: Hex }[];
+}
+
+export interface WsFlushResult {
+  /** Transport-form files written, or null on a runtime without a corestore. */
+  written: number | null;
+}
+
+export interface WsCloseResult {
+  ok: true;
+}

--- a/packages/workspace/src/ipc/remote-base.ts
+++ b/packages/workspace/src/ipc/remote-base.ts
@@ -1,0 +1,293 @@
+// RemoteWorkspace — a Workspace proxy backed by a spawned Node child process.
+//
+// Transport-agnostic: takes an already-constructed, ready-to-use Transport
+// (see @workspace.sh/p2p-runtime/ipc). ./remote.node.ts and ./remote.macos.ts
+// are the thin per-platform files that actually spawn one — this file holds
+// all the shared RPC/event-handling logic so it isn't duplicated per platform.
+//
+// Mirrors @workspace.sh/workspace's own Workspace class shape as closely as
+// possible so call sites read the same either way — but every method here is
+// an RPC round-trip, since the real Workspace instance lives in the child
+// (fs/sodium/ucanto/node:crypto only run there — see ../ipc/child.ts).
+
+// `encode` comes from the framing entry point, NOT the `/ipc` barrel: the
+// barrel re-exports NodeTransport, and an ESM re-export loads eagerly, so a
+// value import from it drags `node:child_process` / `node:url` / `node:path`
+// into whatever bundles this file. That breaks Metro on macOS, which reaches
+// here via ./remote.macos.ts. The barrel's own header flags the same hazard
+// for Bare worklets (#229) — this file is shared by every platform, so it can
+// only ever use the platform-neutral entry points.
+//
+// The `Transport` type below is erased at compile time and never reaches the
+// bundler, so it can keep coming from the barrel.
+import { encode } from '@workspace.sh/p2p-runtime/ipc/framing';
+import type { Transport } from '@workspace.sh/p2p-runtime/ipc';
+import type {
+  ChangeEvent,
+  WorkingTreeEvent,
+  Hex,
+  Method,
+  Params,
+  Request,
+  WsEntriesResult,
+  WsInfoResult,
+  WsListResult,
+} from './protocol.ts';
+
+type ChangeListener = () => void;
+
+interface Pending {
+  resolve: (v: unknown) => void;
+  reject: (e: Error) => void;
+}
+
+/**
+ * Request ids, unique across every RemoteWorkspace rather than within one.
+ *
+ * Each instance used to number its own requests from 1, which was fine while a
+ * workspace owned its child. Sharing a child breaks it: two workspaces both
+ * send id 1, both see every reply on that transport, and each resolves on the
+ * other's answer. A module-scoped counter makes the collision unrepresentable
+ * rather than merely unlikely.
+ */
+let nextRequestId = 1;
+
+export class RemoteWorkspace {
+  /** Opaque child-side identifier for this workspace instance. */
+  readonly handle: string;
+  /** Stable workspace identifier — the root public key, hex. */
+  readonly id: string;
+  /** This peer's DID. */
+  readonly did: string;
+  /** The workspace root authority DID. */
+  readonly rootDid: string;
+  /** True if this handle can invite members (i.e. holds the root key). */
+  readonly isAdmin: boolean;
+
+  private transport: Transport;
+  /**
+   * Whether closing this workspace should close the child process too.
+   *
+   * False when the transport is shared. One child holds many workspaces — the
+   * child has always keyed them by handle, and Corestore replicates every core
+   * it holds over one connection per peer — so closing the transport because
+   * ONE workspace closed would tear down every other workspace with it.
+   */
+  private readonly ownsTransport: boolean;
+  private pending = new Map<number, Pending>();
+  private _length: number;
+  private listeners = new Set<ChangeListener>();
+  private workingTreeListeners = new Set<(path: string, bytes: Uint8Array | null) => void>();
+
+  private constructor(transport: Transport, info: WsInfoResult, ownsTransport: boolean) {
+    this.transport = transport;
+    this.ownsTransport = ownsTransport;
+    this.handle = info.handle;
+    this.id = info.id;
+    this.did = info.did;
+    this.rootDid = info.rootDid;
+    this.isAdmin = info.isAdmin;
+    this._length = info.length;
+    this.transport.onMessage((msg) => this.handleMessage(msg));
+  }
+
+  /** Number of entries currently visible locally. */
+  get length(): number {
+    return this._length;
+  }
+
+  /**
+   * Bootstrap a RemoteWorkspace over an already-spawned, ready transport by
+   * sending the initial wsCreate/wsOpen request. Called by the per-platform
+   * `create`/`open` functions once they've constructed their Transport.
+   */
+  static async fromTransport(
+    transport: Transport,
+    params: Params,
+    /**
+     * Whether this workspace owns the child. Default true, which is the
+     * one-process-per-workspace shape the Node path still uses. The macOS path
+     * passes false: its child is shared and outlives any single workspace.
+     */
+    ownsTransport = true,
+  ): Promise<RemoteWorkspace> {
+    let info: WsInfoResult;
+    try {
+      info = (await RemoteWorkspace.rpcOnce(transport, params)) as WsInfoResult;
+    } catch (err) {
+      // The child is already spawned by the time this call is made, and if the
+      // call fails nothing else holds a reference to it — no RemoteWorkspace
+      // exists to close later. Left running it wedges the singleton native
+      // runtime, so the NEXT open or create fails with "Child process is
+      // already running", blaming an operation that did nothing wrong (#326).
+      //
+      // Pointing at a folder that is not a workspace is the ordinary way in:
+      // the child spawns fine and `wsOpen` then fails on the missing manifest.
+      // Only if we own it: a shared child is still holding other workspaces,
+      // and this open failing says nothing about them.
+      if (ownsTransport) {
+        try {
+          await transport.close();
+        } catch {
+          // A child that will not close cannot be helped from here, and the
+          // caller needs the ORIGINAL failure — not this one.
+        }
+      }
+      throw err;
+    }
+    return new RemoteWorkspace(transport, info, ownsTransport);
+  }
+
+  // One-shot RPC used only for the bootstrap call, before the instance (and
+  // its own `pending` map) exists. id=1 is safe to reuse afterwards — this
+  // listener removes itself the moment the bootstrap response arrives, well
+  // before the constructed instance's own id counter starts issuing calls.
+  private static rpcOnce(transport: Transport, params: Params): Promise<unknown> {
+    // Also from the shared counter. This runs BEFORE the instance exists, so
+    // it used a hardcoded id 1 — which on a shared child would collide with
+    // whatever an already-open workspace happened to be doing.
+    const id = nextRequestId++;
+    return new Promise((resolve, reject) => {
+      const off = transport.onMessage((msg) => {
+        const r = msg as { id: number; ok: boolean; result?: unknown; error?: { message: string } };
+        if (r.id !== id) return;
+        off();
+        if (r.ok) resolve(r.result);
+        else reject(new Error(r.error?.message ?? 'IPC error'));
+      });
+      const req: Request = { id, method: params.method as Method, params };
+      transport.send(encode(req));
+    });
+  }
+
+  /**
+   * Invite a peer by DID. Admin-only (requires the root key) — throws
+   * (via the child's own check) if this handle isn't the admin.
+   */
+  async invite(recipientDid: string): Promise<void> {
+    await this.rpc({ method: 'wsInvite', handle: this.handle, recipientDid });
+  }
+
+  /** Append an entry to the workspace's data log (sealed under K0_org). */
+  async write(entry: Uint8Array): Promise<void> {
+    await this.rpc({ method: 'wsWrite', handle: this.handle, entryHex: bytesToHex(entry) });
+  }
+
+  /** Read all entries, decrypted. */
+  async entries(): Promise<Uint8Array[]> {
+    const r = (await this.rpc({ method: 'wsEntries', handle: this.handle })) as WsEntriesResult;
+    return r.entriesHex.map(hexToBytes);
+  }
+
+  /** Subscribe to "an entry was appended" (local or replicated). */
+  on(event: 'change', cb: ChangeListener): () => void {
+    if (event !== 'change') throw new Error(`unknown event: ${String(event)}`);
+    this.listeners.add(cb);
+    return () => this.listeners.delete(cb);
+  }
+
+  /**
+   * Start (or stop) watching the working tree for external edits.
+   *
+   * Fires for OUR OWN writes too — the filesystem cannot distinguish them —
+   * so the caller must filter echoes before writing back to the log.
+   */
+  /**
+   * One pass over the working tree. See `Workspace.listWorkingTree` — the
+   * watcher reports changes, so a file that merely exists is invisible to it.
+   */
+  async listWorkingTree(options?: {
+    extensions?: string[];
+  }): Promise<{ path: string; bytes: Uint8Array }[]> {
+    const res = (await this.rpc({
+      method: 'wsList',
+      handle: this.handle,
+      ...(options?.extensions ? { extensions: options.extensions } : {}),
+    })) as WsListResult;
+    return res.files.map(f => ({ path: f.path, bytes: hexToBytes(f.bytesHex) }));
+  }
+
+  async watchWorkingTree(cb: (path: string, bytes: Uint8Array | null) => void): Promise<() => void> {
+    this.workingTreeListeners.add(cb);
+    if (this.workingTreeListeners.size === 1) {
+      await this.rpc({ method: 'wsWatch', handle: this.handle, enabled: true });
+    }
+    return () => {
+      this.workingTreeListeners.delete(cb);
+      if (this.workingTreeListeners.size === 0) {
+        void this.rpc({ method: 'wsWatch', handle: this.handle, enabled: false }).catch(() => {});
+      }
+    };
+  }
+
+  /**
+   * Flush the transport form (`.workspace/store/v1/`) so the folder is a
+   * complete copy. Close does this implicitly; call it before sharing.
+   */
+  async flushStore(): Promise<{ written: number } | null> {
+    const r = (await this.rpc({ method: 'wsFlush', handle: this.handle })) as {
+      written: number | null;
+    };
+    return r.written === null ? null : { written: r.written };
+  }
+
+  async close(): Promise<void> {
+    await this.rpc({ method: 'wsClose', handle: this.handle });
+    // `wsClose` releases this workspace inside the child. Whether the child
+    // itself should go is a different question, and the answer is no when it
+    // is shared — other workspaces are still using it.
+    if (this.ownsTransport) await this.transport.close();
+  }
+
+  private rpc(params: Params): Promise<unknown> {
+    const id = nextRequestId++;
+    const req: Request = { id, method: params.method as Method, params };
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.transport.send(encode(req));
+    });
+  }
+
+  private handleMessage(msg: unknown): void {
+    if (!msg || typeof msg !== 'object') return;
+    if ('event' in msg) {
+      const evt = msg as ChangeEvent | WorkingTreeEvent;
+      if (evt.event === 'workingTree' && evt.handle === this.handle) {
+        const wt = evt as WorkingTreeEvent;
+        const bytes = wt.bytesHex === null ? null : hexToBytes(wt.bytesHex);
+        for (const cb of this.workingTreeListeners) cb(wt.path, bytes);
+        return;
+      }
+      if (evt.event === 'change' && evt.handle === this.handle) {
+        this._length = evt.length;
+        for (const cb of this.listeners) cb();
+      }
+      return;
+    }
+    const r = msg as { id: number; ok: boolean; result?: unknown; error?: { message: string } };
+    const pending = this.pending.get(r.id);
+    if (!pending) return;
+    this.pending.delete(r.id);
+    if (r.ok) pending.resolve(r.result);
+    else pending.reject(new Error(r.error?.message ?? 'IPC error'));
+  }
+}
+
+// ----- hex helpers ----------------------------------------------------------
+
+function hexToBytes(hex: Hex): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error('odd-length hex');
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
+  return out;
+}
+
+function bytesToHex(b: Uint8Array): Hex {
+  let s = '';
+  for (let i = 0; i < b.length; i++) {
+    s += b[i]!.toString(16).padStart(2, '0');
+  }
+  return s;
+}

--- a/packages/workspace/src/ipc/remote.ios.ts
+++ b/packages/workspace/src/ipc/remote.ios.ts
@@ -1,0 +1,91 @@
+// Mobile-path RemoteWorkspace — runs the child inside a Bare worklet
+// (`react-native-bare-kit`) instead of spawning a process. Same protocol,
+// same child code; only the transport differs.
+//
+// Serves iOS AND Android: both use the same binding, so there is one file
+// rather than two that start identical and drift.
+//
+// Imported by explicit path (`@workspace.sh/workspace/remote-ios`) rather
+// than relying on Metro's moduleSuffixes, matching how the macOS entry avoids
+// depending on bundler-specific suffix behaviour through a package's exports.
+//
+// Integration checklist:
+//   1. `npm i react-native-bare-kit` and rebuild the dev client — this is a
+//      native module, so a JS-only reload will not pick it up.
+//   2. Bundle the worklet with `yarn mobile:p2p:bundle`.
+//      It must be THIS package's worklet entry (./worklet-bin.ts), not
+//      @workspace.sh/p2p-runtime's — that one serves the Log-level protocol
+//      and would reject every request RemoteWorkspace sends (#243). The
+//      script also needs --preset mobile (ios-arm64 alone excludes the
+//      simulator) and --imports, for the builtins node_modules reaches for.
+//      Pass the resulting bytes as `bundle`; the caller owns asset loading,
+//      which differs between Expo, bare React Native, and a test harness.
+//   3. `storage` is REQUIRED, as on macOS — see docs/workspace-format.md
+//      invariant 4: corestore storage must never default into a folder that
+//      might be cloud-synced.
+
+import { BareTransport, type BareWorklet } from '@workspace.sh/p2p-runtime/ipc/ios';
+import { RemoteWorkspace } from './remote-base.ts';
+import type { BootstrapNode } from './protocol.ts';
+
+/** Bytes of a `bare-pack` bundle, or a path/source string the host resolves. */
+export type WorkletBundle = ArrayBuffer | Uint8Array | string;
+
+export interface RemoteWorkspaceMobileCreateOptions {
+  folder: string;
+  name?: string;
+  rootSeed?: Uint8Array;
+  storage: string;
+  /** Private DHT bootstrap nodes. Omit for the public DHT (production). */
+  bootstrap?: BootstrapNode[];
+  /** A `new Worklet()` from `react-native-bare-kit`. */
+  worklet: BareWorklet;
+  bundle: WorkletBundle;
+}
+
+export interface RemoteWorkspaceMobileOpenOptions {
+  folder: string;
+  identitySeed: Uint8Array;
+  storage: string;
+  bootstrap?: BootstrapNode[];
+  worklet: BareWorklet;
+  bundle: WorkletBundle;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function createWorkspace(
+  opts: RemoteWorkspaceMobileCreateOptions,
+): Promise<RemoteWorkspace> {
+  const transport = new BareTransport({ worklet: opts.worklet });
+  await transport.start(opts.bundle);
+  return RemoteWorkspace.fromTransport(transport, {
+    method: 'wsCreate',
+    folder: opts.folder,
+    name: opts.name,
+    storage: opts.storage,
+    rootSeedHex: opts.rootSeed ? bytesToHex(opts.rootSeed) : undefined,
+    bootstrap: opts.bootstrap,
+  });
+}
+
+export async function openWorkspace(
+  opts: RemoteWorkspaceMobileOpenOptions,
+): Promise<RemoteWorkspace> {
+  const transport = new BareTransport({ worklet: opts.worklet });
+  await transport.start(opts.bundle);
+  return RemoteWorkspace.fromTransport(transport, {
+    method: 'wsOpen',
+    folder: opts.folder,
+    storage: opts.storage,
+    identitySeedHex: bytesToHex(opts.identitySeed),
+    bootstrap: opts.bootstrap,
+  });
+}
+
+export { RemoteWorkspace } from './remote-base.ts';
+export type { BareWorklet } from '@workspace.sh/p2p-runtime/ipc/ios';

--- a/packages/workspace/src/ipc/remote.macos.ts
+++ b/packages/workspace/src/ipc/remote.macos.ts
@@ -1,0 +1,157 @@
+// macOS-path RemoteWorkspace — spawns the child via the P2PRuntimeModule
+// TurboModule (NSTask) instead of child_process.spawn. Same protocol, same
+// child-bin.ts; only the transport differs.
+//
+// Not auto-resolved by Metro's moduleSuffixes — imported by explicit path
+// (`@workspace.sh/workspace/remote-macos`) so platform selection doesn't
+// depend on bundler-specific suffix behaviour through a package's `exports`
+// map. Mirrors @workspace.sh/p2p-runtime/src/runtime.macos.ts.
+//
+// Integration checklist:
+//   1. The P2PRuntimeModule TurboModule (NSTask spawn + stdio bridge) must
+//      be linked into the Xcode target — this file doesn't care WHICH
+//      protocol the spawned child speaks, it's fully generic.
+//   2. childScriptPath must point at packages/workspace/src/ipc/child-bin.ts
+//      (dev: the .ts source directly — the child runs under plain
+//      `node --experimental-strip-types`, not through Metro).
+//   3. storage is REQUIRED — callers must compute an Application Support
+//      path themselves. See docs/workspace-format.md invariant 4: never
+//      default corestore storage into a folder that might be cloud-synced.
+
+import { MacOSTransport } from '@workspace.sh/p2p-runtime/ipc/macos';
+import { RemoteWorkspace } from './remote-base.ts';
+import type { BootstrapNode } from './protocol.ts';
+
+export interface RemoteWorkspaceCreateOptions {
+  folder: string;
+  name?: string;
+  /**
+   * Fixes the WORKSPACE's root identity. Omit for a random one, which is what
+   * every real caller should do — the root public key is the workspaceId and
+   * the swarm topic is a hash of it, so two workspaces sharing a root seed are
+   * one workspace as far as the network is concerned (#317).
+   */
+  rootSeed?: Uint8Array;
+  /** The CREATOR's device identity. Not the same thing as `rootSeed`. */
+  identitySeed?: Uint8Array;
+  storage: string;
+  /** Private DHT bootstrap nodes. Omit for the public DHT (production). */
+  bootstrap?: BootstrapNode[];
+  nodeBin?: string;
+  /** No filesystem-relative default — the bundled path differs per build. */
+  childScriptPath: string;
+}
+
+export interface RemoteWorkspaceOpenOptions {
+  folder: string;
+  identitySeed: Uint8Array;
+  storage: string;
+  bootstrap?: BootstrapNode[];
+  nodeBin?: string;
+  childScriptPath: string;
+}
+
+// ---------------------------------------------------------------------------
+// One child, many workspaces
+// ---------------------------------------------------------------------------
+//
+// The child has always been able to hold many workspaces: `child.ts` keys them
+// by handle and `wsOpen`/`wsClose` operate on entries in that map. Below it,
+// the runtime keeps a Map of joined topics, and Corestore replicates EVERY core
+// it holds over one connection per peer — so ten open workspaces sharing a peer
+// is one connection carrying ten sets of cores, not ten connections.
+//
+// What forced one-workspace-at-a-time was this file: a fresh `MacOSTransport`
+// per call meant a fresh child per call, and the native module is a singleton
+// that refuses the second spawn. The stack was built for this; we were not
+// using it.
+//
+// So the child is spawned once and kept. It outlives any single workspace and
+// is torn down with the app, which is also why a failed open no longer needs to
+// close it (#326 becomes unreachable rather than handled).
+
+let shared: MacOSTransport | null = null;
+let spawning: Promise<MacOSTransport> | null = null;
+
+async function sharedTransport(nodeBin: string, scriptPath: string): Promise<MacOSTransport> {
+  // A child that has exited is not reusable. Respawning here rather than
+  // failing means a crashed child costs one slow operation instead of every
+  // later operation until the app restarts.
+  if (shared !== null && !shared.closed) return shared;
+  // Concurrent opens must not race into two spawns — the second would be
+  // refused, and the first caller would have no idea why.
+  if (spawning !== null) return spawning;
+
+  spawning = (async () => {
+    const transport = new MacOSTransport();
+    try {
+      await transport.spawn(nodeBin, scriptPath, null);
+    } catch (err) {
+      // Cleared so the next attempt tries again rather than awaiting a promise
+      // that has already rejected.
+      spawning = null;
+      throw err;
+    }
+    shared = transport;
+    spawning = null;
+    return transport;
+  })();
+
+  return spawning;
+}
+
+/**
+ * Drop the shared child, for tests and for a deliberate teardown.
+ *
+ * Not called on workspace close: the whole point is that the child outlives
+ * any one workspace.
+ */
+export async function closeSharedTransport(): Promise<void> {
+  const transport = shared;
+  shared = null;
+  spawning = null;
+  if (transport !== null && !transport.closed) await transport.close();
+}
+
+export async function createWorkspace(opts: RemoteWorkspaceCreateOptions): Promise<RemoteWorkspace> {
+  const transport = await sharedTransport(opts.nodeBin ?? 'node', opts.childScriptPath);
+  return RemoteWorkspace.fromTransport(
+    transport,
+    {
+      method: 'wsCreate',
+      folder: opts.folder,
+      name: opts.name,
+      storage: opts.storage,
+      rootSeedHex: opts.rootSeed ? bytesToHex(opts.rootSeed) : undefined,
+      identitySeedHex: opts.identitySeed ? bytesToHex(opts.identitySeed) : undefined,
+      bootstrap: opts.bootstrap,
+    },
+    // Shared: closing this workspace must not take the child with it.
+    false,
+  );
+}
+
+export async function openWorkspace(opts: RemoteWorkspaceOpenOptions): Promise<RemoteWorkspace> {
+  const transport = await sharedTransport(opts.nodeBin ?? 'node', opts.childScriptPath);
+  return RemoteWorkspace.fromTransport(
+    transport,
+    {
+      method: 'wsOpen',
+      folder: opts.folder,
+      storage: opts.storage,
+      identitySeedHex: bytesToHex(opts.identitySeed),
+      bootstrap: opts.bootstrap,
+    },
+    false,
+  );
+}
+
+function bytesToHex(b: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < b.length; i++) {
+    s += b[i]!.toString(16).padStart(2, '0');
+  }
+  return s;
+}
+
+export { RemoteWorkspace };

--- a/packages/workspace/src/ipc/remote.node.ts
+++ b/packages/workspace/src/ipc/remote.node.ts
@@ -1,0 +1,73 @@
+// Node-path RemoteWorkspace — spawns the child via child_process.spawn
+// (NodeTransport). Used by tests, Node-hosted tools, and to prove the IPC
+// layer itself with no native/Xcode involvement at all. The macOS RN app
+// uses remote.macos.ts instead — same protocol, NSTask spawn.
+
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { NodeTransport } from '@workspace.sh/p2p-runtime/ipc';
+import { RemoteWorkspace } from './remote-base.ts';
+import type { BootstrapNode } from './protocol.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CHILD_SCRIPT = resolve(HERE, 'child-bin.ts');
+
+export interface RemoteWorkspaceCreateOptions {
+  folder: string;
+  name?: string;
+  rootSeed?: Uint8Array;
+  /** Required — no invariant-4-violating default at this layer. */
+  storage: string;
+  /** Private DHT bootstrap nodes. Omit for the public DHT (production). */
+  bootstrap?: BootstrapNode[];
+  nodeBin?: string;
+  childScriptPath?: string;
+}
+
+export interface RemoteWorkspaceOpenOptions {
+  folder: string;
+  identitySeed: Uint8Array;
+  storage: string;
+  bootstrap?: BootstrapNode[];
+  nodeBin?: string;
+  childScriptPath?: string;
+}
+
+export async function createWorkspace(opts: RemoteWorkspaceCreateOptions): Promise<RemoteWorkspace> {
+  const transport = new NodeTransport({
+    nodeBin: opts.nodeBin,
+    scriptPath: opts.childScriptPath ?? DEFAULT_CHILD_SCRIPT,
+  });
+  return RemoteWorkspace.fromTransport(transport, {
+    method: 'wsCreate',
+    folder: opts.folder,
+    name: opts.name,
+    storage: opts.storage,
+    rootSeedHex: opts.rootSeed ? bytesToHex(opts.rootSeed) : undefined,
+    bootstrap: opts.bootstrap,
+  });
+}
+
+export async function openWorkspace(opts: RemoteWorkspaceOpenOptions): Promise<RemoteWorkspace> {
+  const transport = new NodeTransport({
+    nodeBin: opts.nodeBin,
+    scriptPath: opts.childScriptPath ?? DEFAULT_CHILD_SCRIPT,
+  });
+  return RemoteWorkspace.fromTransport(transport, {
+    method: 'wsOpen',
+    folder: opts.folder,
+    storage: opts.storage,
+    identitySeedHex: bytesToHex(opts.identitySeed),
+    bootstrap: opts.bootstrap,
+  });
+}
+
+function bytesToHex(b: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < b.length; i++) {
+    s += b[i]!.toString(16).padStart(2, '0');
+  }
+  return s;
+}
+
+export { RemoteWorkspace };

--- a/packages/workspace/src/ipc/worklet-bin.ts
+++ b/packages/workspace/src/ipc/worklet-bin.ts
@@ -1,0 +1,49 @@
+// Entry point for the Bare worklet — the iOS/Android counterpart to
+// `child-bin.ts`, one level up the stack from
+// `@workspace.sh/p2p-runtime`'s own worklet entry.
+//
+// This is the entry the mobile app actually needs. `RemoteWorkspace`
+// (./remote-base.ts, used by both remote.macos.ts and remote.ios.ts) speaks
+// the WORKSPACE-level protocol in ./protocol.ts — create / open / write /
+// entries — so the worklet on the other side of the byte channel has to be a
+// `WorkspaceChild`, exactly as the spawned macOS child is.
+//
+// Bundling p2p-runtime's worklet-bin.ts here instead — which #226's
+// integration checklist said to do — produces a worklet that boots fine and
+// then rejects every request, because it serves the LOG-level protocol
+// (init / createLog / appendBlock) that nothing on the mobile path sends.
+// See #229.
+//
+// The macOS path spawns a Node child and speaks this protocol over
+// stdin/stdout. Mobile has no child processes, so `react-native-bare-kit`
+// runs a Bare instance in-process and gives it a bidirectional byte channel
+// (`BareKit.IPC`) instead of pipes. Everything above the byte channel is
+// identical: this file is `child-bin.ts` with the lines that touch stdio
+// swapped for the ones that touch IPC.
+
+// Bare provides no TextEncoder/TextDecoder globals, and this file runs inside
+// the Bare worklet on iOS/Android. b4a covers both hosts (#243).
+import b4a from 'b4a';
+
+import { WorkspaceChild } from './child.ts';
+
+declare const BareKit: {
+  IPC: {
+    write(data: Uint8Array | string): void;
+    on(event: 'data', cb: (data: Uint8Array) => void): void;
+    on(event: 'close', cb: () => void): void;
+  };
+};
+
+const child = new WorkspaceChild((s) => {
+  BareKit.IPC.write(s);
+});
+
+BareKit.IPC.on('data', (data) => {
+  const chunk = typeof data === 'string' ? data : b4a.toString(data, 'utf8');
+  child.feed(chunk).catch((err: unknown) => {
+    // No stderr to inherit here — the host sees this through liblog, which is
+    // where console output from a worklet goes.
+    console.error(`[ws-worklet] feed crashed: ${(err as Error).stack ?? String(err)}`);
+  });
+});

--- a/packages/workspace/src/paths.ts
+++ b/packages/workspace/src/paths.ts
@@ -1,0 +1,57 @@
+// Which paths in a workspace folder are content, and which are machinery.
+//
+// Split out of `watcher.ts` because that module imports `fs`, and the taxonomy
+// is now needed somewhere `fs` does not exist: the desktop app lists a closed
+// workspace's folder through a native module and filters the result in JS
+// (#309). Importing the watcher there would drag Node's filesystem into a
+// React Native bundle.
+//
+// One copy, deliberately. The exclusion taxonomy is exactly the kind of thing
+// that drifts between the watcher, the tree walk, the seed script and the
+// conformance suite if each keeps its own — and a scan and a watch disagreeing
+// about what counts as a file means a document gets adopted and then never
+// tracked, or tracked and never adopted.
+
+/** The hidden container. Machine-facing; only the app writes it. */
+export const META_DIR = '.workspace';
+
+/** OS junk and VCS/tooling directories — never workspace content. */
+const EXCLUDED_SEGMENTS = new Set([
+  META_DIR,
+  '.git',
+  '.obsidian',
+  'node_modules',
+  '.DS_Store',
+  'Thumbs.db',
+  'desktop.ini',
+]);
+
+/** Editor sidecars: swap files, backups, lock files. */
+function isSidecar(name: string): boolean {
+  return (
+    name.endsWith('.swp') ||
+    name.endsWith('.swx') ||
+    name.endsWith('~') ||
+    name.startsWith('.~lock.') ||
+    // Atomic-save temporaries. The debounce collapses the rename dance, but
+    // the temp file itself must never be reported as a document.
+    name.startsWith('.tmp-') ||
+    name.endsWith('.tmp')
+  );
+}
+
+/**
+ * Whether a workspace-relative path should be reported at all.
+ *
+ * Exported because the exclusion taxonomy is the kind of thing that drifts
+ * between the watcher, the seed script and the conformance suite if each
+ * keeps its own copy.
+ */
+export function isWatchablePath(relPath: string): boolean {
+  if (relPath.length === 0) return false;
+  const segments = relPath.split('/');
+  for (const segment of segments) {
+    if (EXCLUDED_SEGMENTS.has(segment)) return false;
+  }
+  return !isSidecar(segments[segments.length - 1] ?? '');
+}

--- a/packages/workspace/src/watcher.ts
+++ b/packages/workspace/src/watcher.ts
@@ -1,0 +1,332 @@
+// Working-tree watcher.
+//
+// `workspace-format.md` § "External edits — watching the working tree": a
+// workspace folder is meant to behave like Dropbox — open a file in whichever
+// editor you like, save, and Workspace picks up the change. That promise is
+// what makes "the folder IS the workspace" honest.
+//
+// Until now the reverse direction did not exist. An external edit was not
+// merely ignored: `materialise.ts` writes the folded log back to disk, so the
+// next change on any device overwrote it (#221).
+//
+// ## What this module does and does not decide
+//
+// It reports *that a path changed and what the bytes now are*. It does not
+// encode document entries — the log is a byte log and the document model
+// belongs to `@workspace.sh/core` (see `documents.ts`). Keeping the
+// interpretation out of here is what lets the same watcher serve a future
+// format whose entries look nothing like today's.
+//
+// ## Portability
+//
+// One implementation for both hosts. `fs.watch` is imported unprefixed and
+// resolves through the package `imports` map to `bare-fs` under Bare, whose
+// `watch` takes the same `(path, { recursive }, cb)` shape as Node's. No
+// chokidar, no injected platform factory.
+
+import { stat, readFile, readdir } from 'fs/promises';
+import { watch } from 'fs';
+import { join, relative, sep } from 'path';
+
+import { sha256Hex } from '@workspace.sh/p2p-runtime';
+
+// The path taxonomy lives in its own fs-free module so the desktop app can
+// apply the SAME rules to a native directory listing (#309). One copy.
+import { META_DIR, isWatchablePath } from './paths.ts';
+
+export { isWatchablePath };
+
+/** What the watcher saw, once a path stopped moving. */
+export interface WorkingTreeChange {
+  /** Workspace-relative path, `/`-separated regardless of host. */
+  path: string;
+  /** File contents, or null if the path no longer exists. */
+  bytes: Uint8Array | null;
+}
+
+export interface WatchOptions {
+  /**
+   * How long a path must be quiet before it is reported. The spec calls for
+   * 100–300 ms: long enough that one user-level save lands as one ingest even
+   * when the editor writes a temp file and renames over the original (Vim,
+   * Sublime and friends), short enough to feel immediate.
+   */
+  debounceMs?: number;
+  /**
+   * Consecutive identical-size reads required before a file is considered
+   * settled. Guards the 500 MB-video-being-copied-in case: without it a large
+   * write is ingested as several partial copies.
+   */
+  stableReads?: number;
+}
+
+const DEFAULT_DEBOUNCE_MS = 200;
+const DEFAULT_STABLE_READS = 2;
+
+/**
+ * Whether an error means the path is genuinely gone.
+ *
+ * Only ENOENT does. Everything else — EACCES, EIO, a cloud provider failing to
+ * materialise an evicted file — means "could not read", which is emphatically
+ * not the same thing: a `bytes: null` report is taken by the consumer as an
+ * external delete, and appending that tombstone REPLICATES, removing the
+ * document from every device. That is #231's warning, in the read direction.
+ *
+ * So a read that failed for any other reason drops the event entirely. The
+ * watcher will fire again; nothing is lost by waiting, and a great deal is
+ * lost by guessing.
+ */
+function meansGone(err: unknown): boolean {
+  return (err as { code?: string } | null)?.code === 'ENOENT';
+}
+
+
+
+/**
+ * Watch a workspace's working tree.
+ *
+ * Calls `onChange` once per settled path. Returns a stop function; calling it
+ * is required — an unstopped watcher keeps the process alive.
+ */
+export function watchWorkingTree(
+  folder: string,
+  onChange: (change: WorkingTreeChange) => void,
+  options: WatchOptions = {},
+): () => void {
+  const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const stableReads = options.stableReads ?? DEFAULT_STABLE_READS;
+
+  // One timer per path: a flurry of events for the same file collapses into
+  // a single report, which is the whole point of the debounce.
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+  // Paths with a settle in flight. Stabilisation sleeps, and the host keeps
+  // emitting events during that sleep — without this, one save produces two
+  // concurrent settles and two reports.
+  const settling = new Set<string>();
+  // Last reported content digest per path. A change that leaves the bytes
+  // identical is not a change: reporting it would append a redundant entry
+  // to an append-only log, which is the echo problem in miniature.
+  const lastDigest = new Map<string, string | null>();
+  let stopped = false;
+
+  const report = (change: WorkingTreeChange): void => {
+    const digest = change.bytes === null ? null : sha256Hex(change.bytes);
+    if (lastDigest.has(change.path) && lastDigest.get(change.path) === digest) return;
+    lastDigest.set(change.path, digest);
+    onChange(change);
+  };
+
+  const settle = async (relPath: string): Promise<void> => {
+    timers.delete(relPath);
+    if (stopped) return;
+    // Coalesce: a settle already running for this path will re-read the file
+    // when it finishes, so a second one would only duplicate the work.
+    if (settling.has(relPath)) return;
+    settling.add(relPath);
+    try {
+      await settleInner(relPath);
+    } finally {
+      settling.delete(relPath);
+    }
+  };
+
+  const settleInner = async (relPath: string): Promise<void> => {
+
+    const absPath = join(folder, ...relPath.split('/'));
+
+    // Size stabilisation. A file still being written reports a different
+    // size each time; only report once it has held steady.
+    let lastSize = -1;
+    let steady = 0;
+    for (;;) {
+      let size: number;
+      try {
+        const st = await stat(absPath);
+        if (st.isDirectory()) return; // directories are not documents
+        size = st.size;
+      } catch (err) {
+        // Gone: a delete, or the temp half of an atomic save. The caller
+        // decides what that means — and because it decides "deleted", only a
+        // genuine ENOENT may say it.
+        if (meansGone(err)) report({ path: relPath, bytes: null });
+        return;
+      }
+      if (size === lastSize) {
+        if (++steady >= stableReads - 1) break;
+      } else {
+        steady = 0;
+        lastSize = size;
+      }
+      await new Promise(resolve => setTimeout(resolve, debounceMs));
+      if (stopped) return;
+    }
+
+    try {
+      const bytes = await readFile(absPath);
+      if (!stopped) report({ path: relPath, bytes: new Uint8Array(bytes) });
+    } catch (err) {
+      // A file that vanished between the stat loop and here is a real delete.
+      // A file we merely could not read is not, and reporting it as one
+      // deletes the document on every device.
+      if (!stopped && meansGone(err)) report({ path: relPath, bytes: null });
+    }
+  };
+
+  const schedule = (relPath: string): void => {
+    const existing = timers.get(relPath);
+    if (existing) clearTimeout(existing);
+    timers.set(
+      relPath,
+      setTimeout(() => {
+        void settle(relPath);
+      }, debounceMs),
+    );
+  };
+
+  const watcher = watch(folder, { recursive: true }, (_event, filename) => {
+    if (stopped || !filename) return;
+    // Normalise to `/` so a workspace-relative path means the same thing on
+    // every host — it becomes a document key, and the same workspace on
+    // another device must agree about it.
+    const relPath = String(filename).split(sep).join('/');
+    if (!isWatchablePath(relPath)) return;
+    schedule(relPath);
+  });
+
+  return () => {
+    stopped = true;
+    for (const timer of timers.values()) clearTimeout(timer);
+    timers.clear();
+    try {
+      watcher.close();
+    } catch {
+      /* already closed */
+    }
+  };
+}
+
+/** How much of the working tree to read. */
+export interface ListOptions {
+  /**
+   * Only read files ending in one of these (case-insensitive). Omit to read
+   * everything watchable.
+   *
+   * The caller owns this list because it is a document-codec question, not a
+   * filesystem one — but it has to be applied HERE, before the read, or the
+   * bytes are paid for and discarded.
+   */
+  extensions?: string[];
+}
+
+/** One file found in the working tree. */
+export interface WorkingTreeEntry {
+  /** Workspace-relative, `/`-separated — the same key the watcher reports. */
+  path: string;
+  bytes: Uint8Array;
+}
+
+/**
+ * Read every watchable file in the working tree, once.
+ *
+ * The watcher deliberately has no initial scan: it reports *changes*, so a file
+ * that merely exists is invisible to it forever. That is the gap this fills —
+ * it is what lets a reconcile pass see divergence that happened while the
+ * workspace was closed (#280), and files that were in the folder before it was
+ * ever a workspace (#271).
+ *
+ * Shares `isWatchablePath` and the relative-path normalisation with the
+ * watcher, deliberately: if a scan and a watch disagreed about what counts as
+ * a working-tree file, a document could be adopted here and then never tracked,
+ * or tracked and never adopted.
+ *
+ * Unreadable entries are skipped rather than throwing. A workspace folder is a
+ * hostile place — permissions, races with a sync client, symlinks that have
+ * gone nowhere — and one bad file must not deny the caller the other hundred.
+ */
+export async function listWorkingTree(
+  folder: string,
+  options: ListOptions = {},
+): Promise<WorkingTreeEntry[]> {
+  const out: WorkingTreeEntry[] = [];
+  const extensions = options.extensions?.map(e => e.toLowerCase());
+  const wanted = (relPath: string): boolean =>
+    extensions === undefined ||
+    extensions.some(ext => relPath.toLowerCase().endsWith(ext));
+
+  const walk = async (dir: string): Promise<void> => {
+    let names: string[];
+    try {
+      names = await readdir(dir);
+    } catch {
+      return; // unreadable directory — skip the subtree, keep the rest
+    }
+    for (const name of names) {
+      const abs = join(dir, name);
+      const relPath = toWorkspaceRelative(folder, abs);
+      if (relPath === null) continue;
+
+      let st: Awaited<ReturnType<typeof stat>>;
+      try {
+        // Follows symlinks, matching `fs.watch` and the spec's "symlinks are
+        // followed by default".
+        st = await stat(abs);
+      } catch {
+        continue; // vanished mid-walk, or a dangling symlink
+      }
+      const isDir = st.isDirectory();
+
+      if (isDir) {
+        // Prune excluded directories rather than descending: `.workspace/`
+        // holds the container, and `node_modules` is the difference between a
+        // scan and a hang.
+        //
+        // Probed with a synthetic child because `isWatchablePath` answers "is
+        // this a reportable FILE" — it tests every segment for exclusion and
+        // the last one for sidecar-ness. Asking it about `<dir>/x` is
+        // therefore exactly "could anything under this directory be reported",
+        // and reuses the taxonomy instead of duplicating the segment set here.
+        if (!isWatchablePath(`${relPath}/x`)) continue;
+        await walk(abs);
+        continue;
+      }
+
+      if (!isWatchablePath(relPath)) continue;
+      // Filter BEFORE reading. The caller's allowlist used to be applied after
+      // the whole tree had been read and sent across the IPC boundary, so
+      // opening a workspace read every PDF and video in it into memory, hex-
+      // encoded them at twice the size, and threw them away — and on a cloud
+      // volume, forced every evicted file to download first.
+      if (!wanted(relPath)) continue;
+
+      // A file whose data is not present reports its full logical size with no
+      // blocks allocated. Reading it would block on a download, or fail. Skip:
+      // this walk exists to find divergence, and a file we cannot see is not
+      // evidence of any. `st_flags`/SF_DATALESS is not exposed to JS, but
+      // `blocks` is, in both Node and Bare. Inline-compressed tiny files trip
+      // this too — a false positive costs one skipped file, which is the safe
+      // direction.
+      if (st.size > 0 && st.blocks === 0) continue;
+
+      try {
+        const bytes = new Uint8Array(await readFile(abs));
+        // Short of what the kernel just said was there: the file is in motion
+        // — a sync engine mid-write, a copy still running. Adopting a torn
+        // read would append a truncated document to an append-only log.
+        if (bytes.length !== st.size) continue;
+        out.push({ path: relPath, bytes });
+      } catch {
+        continue;
+      }
+    }
+  };
+
+  await walk(folder);
+  return out;
+}
+
+/** Resolve `abs` to a workspace-relative, `/`-separated path, or null if outside. */
+export function toWorkspaceRelative(folder: string, abs: string): string | null {
+  const rel = relative(folder, abs);
+  if (rel.length === 0 || rel.startsWith('..')) return null;
+  return rel.split(sep).join('/');
+}

--- a/packages/workspace/tests/blobs.test.ts
+++ b/packages/workspace/tests/blobs.test.ts
@@ -1,0 +1,283 @@
+// Binary content over a workspace (#234).
+//
+// The motivating case is not exotic: a canvas references images by relative
+// path, so a canvas that syncs without its images renders the broken-image
+// placeholder on the peer — faithfully, because that path is implemented.
+// The cross-peer test below is that case.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  didFromSeed,
+  type CreateRuntimeOptions,
+  type Log,
+  type LogKey,
+  type P2PRuntime,
+  type Did,
+} from '@workspace.sh/p2p-runtime';
+import {
+  BlobIntegrityError,
+  BlobSizeError,
+  CHUNK_BYTES,
+  isBlobRef,
+  MAX_BLOB_BYTES,
+  readBlob,
+  writeBlob,
+  Workspace,
+} from '../src/index.ts';
+
+// Same shared-backing fake as workspace.test.ts: createLog on peer A and
+// openLog(sameKey) on peer B see the same blocks.
+interface Backing {
+  blocks: Uint8Array[];
+  listeners: Set<() => void>;
+}
+
+function makeRuntimeFactory() {
+  const store = new Map<string, Backing>();
+  let counter = 0;
+
+  function viewOf(key: string, writable: boolean): Log {
+    const backing = store.get(key)!;
+    return {
+      key: key as LogKey,
+      writable,
+      get length() {
+        return backing.blocks.length;
+      },
+      async append(b: Uint8Array) {
+        // Copy: callers may hand us a view onto a buffer they reuse.
+        backing.blocks.push(new Uint8Array(b));
+        for (const cb of backing.listeners) cb();
+        return backing.blocks.length;
+      },
+      async get(i: number) {
+        return backing.blocks[i]!;
+      },
+      on(_event: 'append', cb: () => void) {
+        backing.listeners.add(cb);
+        return () => backing.listeners.delete(cb);
+      },
+      async close() {},
+    };
+  }
+
+  const factory = async (opts: CreateRuntimeOptions): Promise<P2PRuntime> => {
+    const did: Did = opts.identitySeed ? didFromSeed(opts.identitySeed) : ('did:key:zFake' as Did);
+    return {
+      async ready() {},
+      did() {
+        return did;
+      },
+      async createLog() {
+        const key = `log${counter++}`.padEnd(8, '0');
+        store.set(key, { blocks: [], listeners: new Set() });
+        return viewOf(key, true);
+      },
+      async openLog(key: LogKey) {
+        if (!store.has(key)) store.set(key, { blocks: [], listeners: new Set() });
+        return viewOf(key, false);
+      },
+      async joinTopic() {},
+      async leaveTopic() {},
+      async close() {},
+    } as P2PRuntime;
+  };
+
+  return factory;
+}
+
+async function withTmp(fn: (folder: string) => Promise<void>): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'ws-blob-test-'));
+  try {
+    await fn(join(base, 'Acme.workspace'));
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+const ROOT_SEED = new Uint8Array(32).fill(1);
+const BOB_SEED = new Uint8Array(32).fill(2);
+
+/** A deterministic byte pattern — catches offset bugs a constant fill would not. */
+function bytes(n: number, seed = 7): Uint8Array {
+  const out = new Uint8Array(n);
+  for (let i = 0; i < n; i++) out[i] = (i * 31 + seed) % 256;
+  return out;
+}
+
+/** A minimal but genuine PNG header, so the fixture is a real file shape. */
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, ...bytes(2048, 3)]);
+const SVG = new TextEncoder().encode(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10"/></svg>',
+);
+
+// ---------------------------------------------------------------------------
+// The motivating case
+// ---------------------------------------------------------------------------
+
+test('a canvas image written by one peer is byte-identical on another', async () => {
+  const createRuntime = makeRuntimeFactory();
+  await withTmp(async folder => {
+    const admin = await Workspace.create({ createRuntime, folder, rootSeed: ROOT_SEED });
+    const bobDid = didFromSeed(BOB_SEED);
+    await admin.invite(bobDid);
+
+    const pngRef = await admin.writeBlob(PNG, { contentType: 'image/png' });
+    const svgRef = await admin.writeBlob(SVG, { contentType: 'image/svg+xml' });
+    // The reference is what a document entry carries, so it must survive JSON.
+    const wire = JSON.parse(JSON.stringify({ png: pngRef, svg: svgRef })) as {
+      png: typeof pngRef;
+      svg: typeof svgRef;
+    };
+    await admin.close();
+
+    const bob = await Workspace.open({ createRuntime, folder, identitySeed: BOB_SEED });
+    assert.ok(isBlobRef(wire.png));
+    assert.deepEqual(await bob.readBlob(wire.png), PNG, 'PNG differs on the peer');
+    assert.deepEqual(await bob.readBlob(wire.svg), SVG, 'SVG differs on the peer');
+    assert.equal(wire.png.contentType, 'image/png');
+    await bob.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The architectural property this design exists for
+// ---------------------------------------------------------------------------
+
+test('blob bytes stay out of the data log', async () => {
+  // The reason blobs get their own log: entries() reads the data log in full
+  // on every change. If blob bytes landed there, every refresh on every peer
+  // would fetch and decrypt them.
+  const createRuntime = makeRuntimeFactory();
+  await withTmp(async folder => {
+    const ws = await Workspace.create({ createRuntime, folder, rootSeed: ROOT_SEED });
+    await ws.write(new TextEncoder().encode('a document'));
+    await ws.writeBlob(bytes(CHUNK_BYTES * 3));
+
+    const entries = await ws.entries();
+    assert.equal(entries.length, 1, 'the blob leaked into the data log');
+    const total = entries.reduce((n, e) => n + e.byteLength, 0);
+    assert.ok(total < 1024, `data log grew to ${total} bytes`);
+    await ws.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chunking and edges
+// ---------------------------------------------------------------------------
+
+for (const [label, size] of [
+  ['empty', 0],
+  ['one byte', 1],
+  ['just under a chunk', CHUNK_BYTES - 1],
+  ['exactly a chunk', CHUNK_BYTES],
+  ['just over a chunk', CHUNK_BYTES + 1],
+  ['several chunks', CHUNK_BYTES * 3 + 17],
+] as const) {
+  test(`round-trips ${label} (${size} bytes)`, async () => {
+    const createRuntime = makeRuntimeFactory();
+    await withTmp(async folder => {
+      const ws = await Workspace.create({ createRuntime, folder, rootSeed: ROOT_SEED });
+      const content = bytes(size);
+      const ref = await ws.writeBlob(content);
+      assert.equal(ref.size, size);
+      assert.equal(ref.chunks.length, Math.ceil(size / CHUNK_BYTES));
+      assert.deepEqual(await ws.readBlob(ref), content);
+      await ws.close();
+    });
+  });
+}
+
+test('identical content is stored once within a session', async () => {
+  const createRuntime = makeRuntimeFactory();
+  await withTmp(async folder => {
+    const ws = await Workspace.create({ createRuntime, folder, rootSeed: ROOT_SEED });
+    const first = await ws.writeBlob(PNG);
+    const second = await ws.writeBlob(PNG);
+    assert.equal(second.id, first.id);
+    assert.deepEqual(second.chunks, first.chunks, 'the same image was stored twice');
+    await ws.close();
+  });
+});
+
+test('different content gets different ids', async () => {
+  const createRuntime = makeRuntimeFactory();
+  await withTmp(async folder => {
+    const ws = await Workspace.create({ createRuntime, folder, rootSeed: ROOT_SEED });
+    const a = await ws.writeBlob(bytes(64, 1));
+    const b = await ws.writeBlob(bytes(64, 2));
+    assert.notEqual(a.id, b.id);
+    await ws.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Refusals
+// ---------------------------------------------------------------------------
+
+test('a blob over the cap is refused with a message a user can act on', async () => {
+  const createRuntime = makeRuntimeFactory();
+  await withTmp(async folder => {
+    const ws = await Workspace.create({ createRuntime, folder, rootSeed: ROOT_SEED });
+    // Not allocated for real — only the length is checked before any write.
+    const huge = { byteLength: MAX_BLOB_BYTES + 1 } as Uint8Array;
+    await assert.rejects(() => ws.writeBlob(huge), BlobSizeError);
+    await assert.rejects(() => ws.writeBlob(huge), /over the .* limit/);
+    await ws.close();
+  });
+});
+
+test('corrupted content fails the integrity check instead of being returned', async () => {
+  // The bytes come from a peer, so "these are what was written" is a claim
+  // worth checking rather than assuming.
+  const blocks: Uint8Array[] = [];
+  const log: Log = {
+    key: 'k' as LogKey,
+    writable: true,
+    get length() {
+      return blocks.length;
+    },
+    async append(b) {
+      blocks.push(new Uint8Array(b));
+      return blocks.length;
+    },
+    async get(i) {
+      return blocks[i]!;
+    },
+    on() {
+      return () => {};
+    },
+    async close() {},
+  };
+
+  const content = bytes(128);
+  const ref = await writeBlob(log, content);
+  blocks[0]![0] = blocks[0]![0]! ^ 0xff; // one flipped bit
+
+  await assert.rejects(() => readBlob(log, ref), BlobIntegrityError);
+});
+
+test('a workspace with no blob log explains itself rather than crashing', async () => {
+  const createRuntime = makeRuntimeFactory();
+  await withTmp(async folder => {
+    const ws = await Workspace.create({ createRuntime, folder, rootSeed: ROOT_SEED });
+    assert.equal(ws.supportsBlobs, true);
+    await ws.close();
+  });
+  // The pre-blob case is the manifest lacking `logs.blobs`; the guard is the
+  // same either way, and its message names the reason.
+});
+
+test('isBlobRef rejects things that are not references', () => {
+  assert.equal(isBlobRef(null), false);
+  assert.equal(isBlobRef({}), false);
+  assert.equal(isBlobRef({ v: 1, id: 'a', size: 1 }), false);
+  assert.equal(isBlobRef({ v: 2, id: 'a', size: 1, chunks: [] }), false);
+  assert.equal(isBlobRef({ v: 1, id: 'a', size: -1, chunks: [] }), false);
+  assert.equal(isBlobRef({ v: 1, id: 'a', size: 0, chunks: [] }), true);
+});

--- a/packages/workspace/tests/transport.test.ts
+++ b/packages/workspace/tests/transport.test.ts
@@ -1,0 +1,398 @@
+// The transport form, proven end to end (workspace#249 phase 3).
+//
+// These tests use the REAL NodeRuntime — real corestores, real Hypercore
+// replication for the flush capture — with `bootstrap: []` so no test ever
+// touches the DHT. The two runtimes in the invariant-5 test never connect:
+// the copied FOLDER is the only channel between them, which is the claim
+// being proven.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { cp, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createRuntime } from '@workspace.sh/p2p-runtime/node';
+import { didFromSeed, type CreateRuntimeOptions } from '@workspace.sh/p2p-runtime';
+import { Workspace } from '../src/index.ts';
+import { RemoteWorkspace } from '../src/ipc/remote-base.ts';
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+const ROOT_SEED = new Uint8Array(32).fill(7);
+const BOB_SEED = new Uint8Array(32).fill(8);
+
+/** Real runtime, isolated storage, no swarm at all. */
+function offlineRuntime(base: string, name: string) {
+  return (opts: CreateRuntimeOptions) =>
+    // `swarm: false` rather than only `bootstrap: []`: an empty bootstrap
+    // still builds a Hyperswarm, and its UDP socket survives `destroy()`
+    // (#254), so the test child cannot exit and the file is cancelled at the
+    // timeout. These tests copy folders; they never replicate over a network.
+    createRuntime({ ...opts, storage: join(base, name), swarm: false });
+}
+
+async function withBase(fn: (base: string) => Promise<void>): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'ws-transport-'));
+  try {
+    await fn(base);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+test('a freshly created workspace has the full on-disk shape', async () => {
+  await withBase(async base => {
+    const folder = join(base, 'acme.workspace');
+    const ws = await Workspace.create({
+      createRuntime: offlineRuntime(base, 'store-a'),
+      folder,
+      rootSeed: ROOT_SEED,
+    });
+    const dirs = await readdir(join(folder, '.workspace', 'store', 'v1'));
+    // One transport dir per log named in the manifest: data, keyDelivery, blobs.
+    assert.equal(dirs.length, 3, `expected 3 log dirs, got ${JSON.stringify(dirs)}`);
+    await ws.close();
+  });
+});
+
+test('INVARIANT 5: cp -R, then a cold open on a runtime that never met the writer', async () => {
+  await withBase(async base => {
+    const folder = join(base, 'acme.workspace');
+
+    const admin = await Workspace.create({
+      createRuntime: offlineRuntime(base, 'store-a'),
+      folder,
+      rootSeed: ROOT_SEED,
+    });
+    await admin.invite(didFromSeed(BOB_SEED));
+    await admin.write(enc.encode('first document'));
+    await admin.write(enc.encode('second document'));
+    const blobBytes = new Uint8Array(70_000).map((_, i) => (i * 13 + 5) % 256);
+    const ref = await admin.writeBlob(blobBytes, { contentType: 'image/png' });
+    const wireRef = JSON.parse(JSON.stringify(ref)) as typeof ref;
+    await admin.close(); // close flushes
+
+    // The only channel between the two runtimes: a plain filesystem copy.
+    const copy = join(base, 'copy.workspace');
+    await cp(folder, copy, { recursive: true });
+
+    const bob = await Workspace.open({
+      createRuntime: offlineRuntime(base, 'store-b'),
+      folder: copy,
+      identitySeed: BOB_SEED,
+    });
+    const entries = await bob.entries();
+    assert.equal(entries.length, 2);
+    assert.equal(dec.decode(entries[0]), 'first document');
+    assert.equal(dec.decode(entries[1]), 'second document');
+    assert.deepEqual(await bob.readBlob(wireRef), blobBytes, 'blob differs across the copy');
+    await bob.close();
+  });
+});
+
+test('a mid-write copy is valid but stale', async () => {
+  await withBase(async base => {
+    const folder = join(base, 'acme.workspace');
+    const admin = await Workspace.create({
+      createRuntime: offlineRuntime(base, 'store-a'),
+      folder,
+      rootSeed: ROOT_SEED,
+    });
+    await admin.invite(didFromSeed(BOB_SEED));
+    await admin.write(enc.encode('flushed'));
+    await admin.flushStore();
+    await admin.write(enc.encode('not yet flushed'));
+
+    // Copy while the writer is still open, before the next flush.
+    const copy = join(base, 'copy.workspace');
+    await cp(folder, copy, { recursive: true });
+    await admin.close();
+
+    const bob = await Workspace.open({
+      createRuntime: offlineRuntime(base, 'store-b'),
+      folder: copy,
+      identitySeed: BOB_SEED,
+    });
+    const entries = await bob.entries();
+    assert.equal(entries.length, 1, 'stale copy should hold exactly the flushed prefix');
+    assert.equal(dec.decode(entries[0]), 'flushed');
+    await bob.close();
+  });
+});
+
+test('a tampered store file is skipped, not trusted', async () => {
+  await withBase(async base => {
+    const folder = join(base, 'acme.workspace');
+    const admin = await Workspace.create({
+      createRuntime: offlineRuntime(base, 'store-a'),
+      folder,
+      rootSeed: ROOT_SEED,
+    });
+    await admin.invite(didFromSeed(BOB_SEED));
+    await admin.write(enc.encode('intact'));
+    await admin.write(enc.encode('to be corrupted'));
+    await admin.close();
+
+    const copy = join(base, 'copy.workspace');
+    await cp(folder, copy, { recursive: true });
+
+    // Corrupt the LAST message file of the data log in the copy.
+    const v1 = join(copy, '.workspace', 'store', 'v1');
+    for (const logDir of await readdir(v1)) {
+      const dir = join(v1, logDir);
+      const files = (await readdir(dir)).sort();
+      if (files.length < 2) continue; // only the data log has multiple messages
+      const target = join(dir, files[files.length - 1]!);
+      const bytes = new Uint8Array(await readFile(target));
+      bytes[bytes.byteLength - 4] = bytes[bytes.byteLength - 4]! ^ 0xff;
+      await writeFile(target, bytes);
+    }
+
+    const bob = await Workspace.open({
+      createRuntime: offlineRuntime(base, 'store-b'),
+      folder: copy,
+      identitySeed: BOB_SEED,
+    });
+    const entries = await bob.entries();
+    assert.ok(entries.length < 2, 'the corrupted tail must not fold in');
+    for (const e of entries) assert.equal(dec.decode(e), 'intact');
+    await bob.close();
+  });
+});
+
+test('re-flushing writes nothing new when the folder is current', async () => {
+  await withBase(async base => {
+    const folder = join(base, 'acme.workspace');
+    const ws = await Workspace.create({
+      createRuntime: offlineRuntime(base, 'store-a'),
+      folder,
+      rootSeed: ROOT_SEED,
+    });
+    await ws.write(enc.encode('one'));
+    const first = await ws.flushStore();
+    assert.ok(first !== null && first.written > 0);
+    const second = await ws.flushStore();
+    assert.equal(second?.written, 0, 'an unchanged workspace must flush zero files');
+    await ws.close();
+  });
+});
+
+test('a failed open closes the child rather than leaking it', async () => {
+  // The chain this breaks (#326): pointing Locate at a folder that is not a
+  // workspace spawns a child fine, `wsOpen` then fails on the missing
+  // manifest, and the child is left running. The singleton native runtime then
+  // refuses the NEXT spawn with "Child process is already running", blaming an
+  // operation that did nothing wrong.
+  let closed = false;
+  let deliver: ((msg: unknown) => void) | null = null;
+
+  const transport = {
+    async spawn() {},
+    send() {
+      // Reply the way the child does when `wsOpen` finds no manifest.
+      queueMicrotask(() =>
+        deliver?.({ id: 1, ok: false, error: { message: 'ENOENT: no such file or directory' } }),
+      );
+    },
+    onMessage(cb: (msg: unknown) => void) {
+      deliver = cb;
+      return () => { deliver = null; };
+    },
+    onExit() { return () => {}; },
+    async close() { closed = true; },
+    get closed() { return closed; },
+  };
+
+  await assert.rejects(
+    () => RemoteWorkspace.fromTransport(transport as never, { method: 'wsOpen' } as never),
+    /ENOENT/,
+    'the original failure reaches the caller',
+  );
+  assert.equal(closed, true, 'and the child was closed on the way out');
+});
+
+// ---------------------------------------------------------------------------
+// One child, many workspaces (#314)
+// ---------------------------------------------------------------------------
+//
+// The stack below this file was always built for it: the child keys workspaces
+// by handle, the runtime keeps a Map of joined topics, and Corestore replicates
+// every core it holds over ONE connection per peer. What forced
+// one-at-a-time was a fresh transport — and so a fresh child — per open.
+
+/** A fake child that holds many workspaces and echoes handles back. */
+function fakeChild() {
+  const listeners = new Set<(msg: unknown) => void>();
+  const sent: { id: number; method: string; params: { handle?: string } }[] = [];
+  let handles = 0;
+  let closed = false;
+
+  const emit = (msg: unknown) => { for (const cb of [...listeners]) cb(msg); };
+
+  const transport = {
+    async spawn() {},
+    send(line: string) {
+      // The transport carries newline-delimited JSON, not bytes.
+      const req = JSON.parse(line) as typeof sent[number];
+      sent.push(req);
+      queueMicrotask(() => {
+        if (req.method === 'wsOpen' || req.method === 'wsCreate') {
+          const handle = `h${++handles}`;
+          emit({
+            id: req.id,
+            ok: true,
+            result: {
+              handle,
+              id: `ws-${handle}`,
+              did: 'did:key:zSelf',
+              rootDid: 'did:key:zRoot',
+              isAdmin: true,
+              length: 0,
+            },
+          });
+          return;
+        }
+        // Echo the handle, so a reply can be attributed to a workspace.
+        emit({ id: req.id, ok: true, result: { handle: req.params.handle } });
+      });
+    },
+    onMessage(cb: (msg: unknown) => void) {
+      listeners.add(cb);
+      return () => listeners.delete(cb);
+    },
+    onExit() { return () => {}; },
+    async close() { closed = true; },
+    get closed() { return closed; },
+  };
+
+  return { transport, sent, isClosed: () => closed };
+}
+
+test('two workspaces share one child and get distinct request ids', async () => {
+  // The collision this prevents: every RemoteWorkspace numbered its own
+  // requests from 1, and `rpcOnce` hardcoded id 1. Sharing a child means both
+  // see every reply on that transport, so two requests numbered 1 would each
+  // resolve on the other's answer — silently, with the wrong data.
+  const { transport, sent } = fakeChild();
+
+  const a = await RemoteWorkspace.fromTransport(
+    transport as never, { method: 'wsOpen' } as never, false);
+  const b = await RemoteWorkspace.fromTransport(
+    transport as never, { method: 'wsOpen' } as never, false);
+
+  assert.notEqual(a.handle, b.handle, 'the child gave them separate handles');
+
+  await Promise.all([a.close(), b.close()]);
+
+  const ids = sent.map(r => r.id);
+  assert.equal(new Set(ids).size, ids.length, 'every request id is distinct');
+});
+
+test('closing one workspace does not close a shared child', async () => {
+  // The child outlives any single workspace — that is the point. Closing the
+  // transport because ONE workspace closed would tear down every other
+  // workspace still using it.
+  const { transport, isClosed } = fakeChild();
+
+  const a = await RemoteWorkspace.fromTransport(
+    transport as never, { method: 'wsOpen' } as never, false);
+  const b = await RemoteWorkspace.fromTransport(
+    transport as never, { method: 'wsOpen' } as never, false);
+
+  await a.close();
+  assert.equal(isClosed(), false, 'the child is still up for b');
+
+  await b.close();
+  assert.equal(isClosed(), false, 'and stays up — it is torn down with the app');
+});
+
+test('a workspace that owns its child closes it', async () => {
+  // The Node path still spawns per workspace, and must keep working that way.
+  const { transport, isClosed } = fakeChild();
+  const ws = await RemoteWorkspace.fromTransport(
+    transport as never, { method: 'wsOpen' } as never);
+  await ws.close();
+  assert.equal(isClosed(), true);
+});
+
+// ---------------------------------------------------------------------------
+// The folder keeps its log without being closed (#341)
+// ---------------------------------------------------------------------------
+//
+// The transport form used to be written only by `close()`. Nothing closes a
+// workspace — quitting terminates the child, and since workspaces became live
+// by default they are never closed at all — so folders were left with a
+// manifest and no log. That opens as a workspace with no documents rather than
+// failing, which is worse than an obvious error, and it breaks invariant 5.
+
+test('a write puts the log in the folder without anyone closing it', async () => {
+  await withBase(async base => {
+    const folder = join(base, 'acme.workspace');
+    const admin = await Workspace.create({
+      createRuntime: offlineRuntime(base, 'store-a'),
+      folder,
+      rootSeed: ROOT_SEED,
+    });
+    await admin.invite(didFromSeed(BOB_SEED));
+    await admin.write(enc.encode('written, never closed'));
+
+    // Wait for the debounce rather than calling flushStore — the point is that
+    // nothing asked for this.
+    await new Promise(resolve => setTimeout(resolve, 2_500));
+
+    // Copy WITHOUT closing, exactly as `cp -R` on a running app would.
+    const copy = join(base, 'copy.workspace');
+    await cp(folder, copy, { recursive: true });
+
+    const bob = await Workspace.open({
+      createRuntime: offlineRuntime(base, 'store-b'),
+      folder: copy,
+      identitySeed: BOB_SEED,
+    });
+    const entries = await bob.entries();
+    assert.equal(entries.length, 1, 'the copy carries the log, not just a manifest');
+    assert.equal(dec.decode(entries[0]!), 'written, never closed');
+    await bob.close();
+    await admin.close();
+  });
+});
+
+test('a burst of writes costs one flush, not one per write', async () => {
+  // A flush replicates the whole log into a capture replica. Per-append would
+  // make every keystroke pay for that.
+  await withBase(async base => {
+    const folder = join(base, 'acme.workspace');
+    let flushes = 0;
+    const base_factory = offlineRuntime(base, 'store-a');
+    const counting = async (opts: never) => {
+      const runtime = await base_factory(opts);
+      const original = runtime.flushLogToDir!.bind(runtime);
+      return Object.assign(runtime, {
+        flushLogToDir: (key: never, dir: never) => {
+          flushes++;
+          return original(key, dir);
+        },
+      });
+    };
+
+    const ws = await Workspace.create({
+      createRuntime: counting as never,
+      folder,
+      rootSeed: ROOT_SEED,
+    });
+    // `create` flushes once itself, which is legitimate — it is what puts the
+    // manifest's logs in the folder before anything is written. Count only
+    // what the writes cause.
+    flushes = 0;
+
+    for (const n of [1, 2, 3, 4, 5]) await ws.write(enc.encode(`v${n}`));
+    await new Promise(resolve => setTimeout(resolve, 2_500));
+
+    // Three logs are flushed per pass (data, key delivery, blobs), so one
+    // debounced pass is three calls — not fifteen.
+    assert.equal(flushes, 3, `expected one pass over three logs, saw ${flushes} calls`);
+    await ws.close();
+  });
+});

--- a/packages/workspace/tests/watcher.test.ts
+++ b/packages/workspace/tests/watcher.test.ts
@@ -1,0 +1,380 @@
+// Working-tree watcher (#221).
+//
+// Real filesystem, real timers: a watcher that is only tested against a fake
+// fs proves nothing about the thing it exists to survive — editors that write
+// a temp file and rename over the original, and large files still being
+// copied in.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdir, mkdtemp, rename, rm, unlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  isWatchablePath,
+  listWorkingTree,
+  toWorkspaceRelative,
+  watchWorkingTree,
+  type WorkingTreeChange,
+} from '../src/watcher.ts';
+
+const DEBOUNCE = 40;
+
+/**
+ * Collect changes while `body` runs.
+ *
+ * `until` waits for a predicate rather than a fixed sleep. These tests use
+ * real timers over a real filesystem, and the runner executes test FILES in
+ * parallel — a fixed sleep that passes alone becomes flaky the moment a
+ * sibling suite (corestore replication, say) loads the machine. Polling for
+ * the expected state removes that coupling; only the absence assertions have
+ * to wait out a settle period, and they get a generous one.
+ */
+async function collect(
+  folder: string,
+  body: () => Promise<void>,
+  until?: (seen: WorkingTreeChange[]) => boolean,
+): Promise<WorkingTreeChange[]> {
+  const seen: WorkingTreeChange[] = [];
+  const stop = watchWorkingTree(folder, ch => seen.push(ch), {
+    debounceMs: DEBOUNCE,
+    stableReads: 2,
+  });
+  try {
+    await body();
+    if (until) {
+      const deadline = Date.now() + 10_000;
+      while (!until(seen) && Date.now() < deadline) {
+        await new Promise(r => setTimeout(r, DEBOUNCE / 2));
+      }
+    }
+    // A short quiet period after the condition, so a duplicate event that
+    // should NOT arrive has a chance to, and the collapse assertions mean
+    // something.
+    await new Promise(r => setTimeout(r, DEBOUNCE * 4));
+  } finally {
+    stop();
+  }
+  return seen;
+}
+
+/** Settle time for tests asserting that NOTHING is reported. */
+const QUIET_MS = DEBOUNCE * 12;
+
+async function withFolder(fn: (folder: string) => Promise<void>): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'ws-watch-'));
+  const folder = join(base, 'acme.workspace');
+  await mkdir(join(folder, '.workspace'), { recursive: true });
+  try {
+    await fn(folder);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+const text = (bytes: Uint8Array | null) =>
+  bytes === null ? null : new TextDecoder().decode(bytes);
+
+// ---------------------------------------------------------------------------
+// The promise the format makes
+// ---------------------------------------------------------------------------
+
+test('an external edit is reported with its new contents', async () => {
+  await withFolder(async folder => {
+    await writeFile(join(folder, 'notes.md'), '# original\n');
+    const seen = await collect(folder, async () => {
+      await new Promise(r => setTimeout(r, DEBOUNCE * 2));
+      await writeFile(join(folder, 'notes.md'), '# edited externally\n');
+    }, seen => seen.some(c => c.path === 'notes.md'));
+    const hit = seen.find(c => c.path === 'notes.md');
+    assert.ok(hit, `no event for notes.md; saw ${JSON.stringify(seen.map(s => s.path))}`);
+    assert.equal(text(hit.bytes), '# edited externally\n');
+  });
+});
+
+test('a nested file reports a workspace-relative path', async () => {
+  await withFolder(async folder => {
+    await mkdir(join(folder, 'ideas'), { recursive: true });
+    const seen = await collect(folder, async () => {
+      await writeFile(join(folder, 'ideas', 'q2.md'), 'nested\n');
+    }, seen => seen.some(c => c.path === 'ideas/q2.md'));
+    assert.ok(
+      seen.some(c => c.path === 'ideas/q2.md'),
+      `expected ideas/q2.md, saw ${JSON.stringify(seen.map(s => s.path))}`,
+    );
+  });
+});
+
+test('a deleted file reports null bytes', async () => {
+  await withFolder(async folder => {
+    await writeFile(join(folder, 'gone.md'), 'here\n');
+    const seen = await collect(folder, async () => {
+      await new Promise(r => setTimeout(r, DEBOUNCE * 2));
+      await unlink(join(folder, 'gone.md'));
+    }, seen => seen.some(c => c.path === 'gone.md' && c.bytes === null));
+    const hit = seen.find(c => c.path === 'gone.md');
+    assert.ok(hit, 'no event for the deletion');
+    assert.equal(hit.bytes, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The cases that make it survive real editors
+// ---------------------------------------------------------------------------
+
+test('an atomic save (temp write + rename) collapses to ONE report of the final file', async () => {
+  // Vim/Sublime write `foo.md.tmp` then rename over `foo.md`. The debounce is
+  // what makes this one ingest rather than three, with no per-editor casing.
+  await withFolder(async folder => {
+    await writeFile(join(folder, 'doc.md'), 'v1\n');
+    const seen = await collect(folder, async () => {
+      await new Promise(r => setTimeout(r, DEBOUNCE * 2));
+      const tmp = join(folder, 'doc.md.tmp');
+      await writeFile(tmp, 'v2 via atomic save\n');
+      await rename(tmp, join(folder, 'doc.md'));
+    }, seen => seen.some(c => c.path === 'doc.md'));
+    const docEvents = seen.filter(c => c.path === 'doc.md');
+    assert.equal(docEvents.length, 1, `expected 1 event, got ${docEvents.length}`);
+    assert.equal(text(docEvents[0]!.bytes), 'v2 via atomic save\n');
+    // The temp file must never surface as a document.
+    assert.equal(seen.filter(c => c.path.endsWith('.tmp')).length, 0);
+  });
+});
+
+test('rapid successive writes collapse to one report with the final contents', async () => {
+  await withFolder(async folder => {
+    const seen = await collect(folder, async () => {
+      const f = join(folder, 'fast.md');
+      for (const v of ['a', 'b', 'c', 'final']) await writeFile(f, `${v}\n`);
+    }, seen => seen.some(c => c.path === 'fast.md'));
+    const events = seen.filter(c => c.path === 'fast.md');
+    assert.equal(events.length, 1, `expected 1 event, got ${events.length}`);
+    assert.equal(text(events[0]!.bytes), 'final\n');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exclusions — invariant 1's hidden directory, and the noise around it
+// ---------------------------------------------------------------------------
+
+test('changes inside .workspace/ are never reported', async () => {
+  // The container is machine-facing: only the app writes it, and ingesting
+  // our own store writes would be an unbounded echo loop.
+  await withFolder(async folder => {
+    const seen = await collect(folder, async () => {
+      await mkdir(join(folder, '.workspace', 'store', 'v1', 'abc'), { recursive: true });
+      await writeFile(join(folder, '.workspace', 'store', 'v1', 'abc', '000000'), 'block');
+      await writeFile(join(folder, '.workspace', 'manifest.json'), '{}');
+      await new Promise(r => setTimeout(r, QUIET_MS));
+    });
+    assert.deepEqual(seen.filter(c => c.path.startsWith('.workspace')), []);
+  });
+});
+
+test('OS junk and editor sidecars are filtered', () => {
+  for (const bad of [
+    '.workspace/manifest.json',
+    '.git/config',
+    'node_modules/x/index.js',
+    '.DS_Store',
+    'notes/.DS_Store',
+    'doc.md.swp',
+    'doc.md~',
+    '.~lock.doc.md#',
+    'ideas/.obsidian/app.json',
+  ]) {
+    assert.equal(isWatchablePath(bad), false, `should be excluded: ${bad}`);
+  }
+  for (const good of ['notes.md', 'ideas/q2.canvas', 'data/customers.table/rows.ndjson', 'keys/notes.md']) {
+    assert.equal(isWatchablePath(good), true, `should be watched: ${good}`);
+  }
+});
+
+test('toWorkspaceRelative refuses paths outside the folder', () => {
+  assert.equal(toWorkspaceRelative('/a/b', '/a/b/notes.md'), 'notes.md');
+  assert.equal(toWorkspaceRelative('/a/b', '/a/b/x/y.md'), 'x/y.md');
+  assert.equal(toWorkspaceRelative('/a/b', '/a/elsewhere.md'), null);
+  assert.equal(toWorkspaceRelative('/a/b', '/a/b'), null);
+});
+
+test('stopping is idempotent and silences further events', async () => {
+  await withFolder(async folder => {
+    const seen: WorkingTreeChange[] = [];
+    const stop = watchWorkingTree(folder, c => seen.push(c), { debounceMs: DEBOUNCE });
+    stop();
+    stop(); // must not throw
+    await writeFile(join(folder, 'after-stop.md'), 'x\n');
+    await new Promise(r => setTimeout(r, QUIET_MS));
+    assert.deepEqual(seen, []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A read error is not a deletion (#289)
+//
+// `bytes: null` is taken by the consumer as an external delete, and that
+// tombstone REPLICATES — so a file the watcher merely could not read would be
+// removed from every device. Only ENOENT may say "gone".
+// ---------------------------------------------------------------------------
+
+test('an unreadable file is not reported as deleted', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'ws-unreadable-'));
+  try {
+    const target = join(dir, 'secret.md');
+    await writeFile(target, 'contents that must not be tombstoned');
+
+    const seen = await collect(dir, async () => {
+      // Deny reads without removing the file: `stat` still succeeds and the
+      // size is stable, so the walk reaches `readFile` and fails there with
+      // EACCES — the exact shape a cloud provider produces when it cannot
+      // materialise an evicted file.
+      await chmod(target, 0o000);
+      await writeFile(join(dir, 'trigger.md'), 'unrelated');
+    });
+
+    await chmod(target, 0o644); // restore before the temp dir is removed
+
+    // Scoped to the file itself. macOS `fs.watch` also emits an event naming
+    // the watched directory, which stats as ENOENT and is reported as gone —
+    // harmless, because the consumer ignores paths it never tracked, but not
+    // what this test is about.
+    assert.ok(
+      !seen.some(c => c.path === 'secret.md' && c.bytes === null),
+      'a read failure must never be reported as a deletion',
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('a genuinely deleted file is still reported as gone', async () => {
+  // The other half: narrowing to ENOENT must not stop real deletions working.
+  const dir = await mkdtemp(join(tmpdir(), 'ws-deleted-'));
+  try {
+    const target = join(dir, 'gone.md');
+    await writeFile(target, 'here for now');
+
+    const seen = await collect(
+      dir,
+      async () => {
+        await unlink(target);
+      },
+      s => s.some(c => c.path === 'gone.md' && c.bytes === null),
+    );
+
+    assert.ok(
+      seen.some(c => c.path === 'gone.md' && c.bytes === null),
+      'ENOENT must still mean deleted',
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// One-shot scan (#280)
+//
+// The watcher reports CHANGES, so a file that merely exists is invisible to it
+// forever. That gap is how divergence occurring while a workspace was closed
+// went unseen — and then got overwritten. These cover the scan that fills it.
+// ---------------------------------------------------------------------------
+
+test('listWorkingTree reports files that already existed', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'ws-list-'));
+  try {
+    await writeFile(join(dir, 'a.md'), 'A');
+    await mkdir(join(dir, 'notes'), { recursive: true });
+    await writeFile(join(dir, 'notes', 'b.md'), 'B');
+
+    const found = await listWorkingTree(dir);
+    const byPath = new Map(found.map(f => [f.path, new TextDecoder().decode(f.bytes)]));
+
+    assert.equal(byPath.size, 2);
+    assert.equal(byPath.get('a.md'), 'A');
+    // Workspace-relative and `/`-separated — the same key the watcher reports,
+    // which is what lets the two be compared at all.
+    assert.equal(byPath.get('notes/b.md'), 'B');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('listWorkingTree applies the same exclusions as the watcher', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'ws-list-'));
+  try {
+    await writeFile(join(dir, 'keep.md'), 'keep');
+    // The container, VCS/tooling directories, OS junk and editor sidecars.
+    for (const seg of ['.workspace', '.git', 'node_modules', '.obsidian']) {
+      await mkdir(join(dir, seg), { recursive: true });
+      await writeFile(join(dir, seg, 'inside.md'), 'no');
+    }
+    await writeFile(join(dir, '.DS_Store'), 'no');
+    await writeFile(join(dir, 'draft.md.swp'), 'no');
+    await writeFile(join(dir, 'notes.md~'), 'no');
+    await writeFile(join(dir, '.tmp-123'), 'no');
+
+    const found = await listWorkingTree(dir);
+    assert.deepEqual(found.map(f => f.path), ['keep.md']);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('listWorkingTree only reads what the caller asked for', async () => {
+  // The filter has to apply BEFORE the read: applying it downstream meant
+  // every binary in the folder was read into memory and hex-encoded across
+  // the IPC boundary just to be discarded (#293).
+  const dir = await mkdtemp(join(tmpdir(), 'ws-list-'));
+  try {
+    await writeFile(join(dir, 'note.md'), 'text');
+    await writeFile(join(dir, 'photo.png'), 'not really a png');
+    await writeFile(join(dir, 'data.bin'), 'binary');
+
+    const found = await listWorkingTree(dir, { extensions: ['.md', '.txt'] });
+    assert.deepEqual(found.map(f => f.path), ['note.md']);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('listWorkingTree matches extensions case-insensitively', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'ws-list-'));
+  try {
+    await writeFile(join(dir, 'SHOUTING.MD'), 'text');
+    const found = await listWorkingTree(dir, { extensions: ['.md'] });
+    assert.deepEqual(found.map(f => f.path), ['SHOUTING.MD']);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('listWorkingTree reads a settled file whole', async () => {
+  // The size and dataless guards both compare the bytes read against what
+  // `stat` reported. This pins the NEGATIVE case — that an ordinary file is
+  // not caught by them.
+  //
+  // The positive cases are not reachable from a test: producing a genuinely
+  // torn read means winning a race against a writer, and producing a dataless
+  // file means having a cloud provider evict one. Both are asserted by
+  // construction in the walk and verified by inspection, not here. Saying so
+  // is better than a test whose name claims more than it checks.
+  const dir = await mkdtemp(join(tmpdir(), 'ws-settled-'));
+  try {
+    await writeFile(join(dir, 'whole.md'), 'complete');
+    const found = await listWorkingTree(dir, { extensions: ['.md'] });
+    assert.equal(found.length, 1);
+    assert.equal(new TextDecoder().decode(found[0]!.bytes), 'complete');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('listWorkingTree is empty for an empty folder, not an error', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'ws-list-'));
+  try {
+    assert.deepEqual(await listWorkingTree(dir), []);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/workspace/tests/workspace.test.ts
+++ b/packages/workspace/tests/workspace.test.ts
@@ -14,6 +14,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { didFromSeed, type CreateRuntimeOptions, type Log, type LogKey, type P2PRuntime, type Did } from '@workspace.sh/p2p-runtime';
+import { readBundleFolder } from '@workspace.sh/portable-bootstrap';
+
 import { Workspace } from '../src/index.ts';
 
 const enc = new TextEncoder();
@@ -167,6 +169,50 @@ test('invite + open: an invited member opens the folder and reads the data', asy
   });
 });
 
+test('the creator can close and reopen their own workspace', async () => {
+  const createRuntime = makeRuntimeFactory();
+  await withTmp(async (folder) => {
+    const admin = await Workspace.create({ createRuntime, folder, rootSeed: ROOT_SEED });
+    const rootDid = admin.rootDid;
+    const id = admin.id;
+    await admin.write(enc.encode('written before closing'));
+    await admin.close();
+
+    // The gap this covers: `create` built the creator's envelope, took its
+    // UCAN for the auth gate and discarded it, so the folder was written with
+    // no envelopes. Everything worked until the process that created the
+    // workspace went away — and then its own author was locked out. Being
+    // root is not what `open` checks; it looks for an envelope addressed to
+    // the opening DID, exactly as it does for anyone else.
+    const reopened = await Workspace.open({ createRuntime, folder, identitySeed: ROOT_SEED });
+    assert.equal(reopened.id, id);
+    assert.equal(reopened.rootDid, rootDid);
+    assert.equal(reopened.did, rootDid);
+
+    const entries = await reopened.entries();
+    assert.deepEqual(entries.map((e) => dec.decode(e)), ['written before closing']);
+
+    await reopened.close();
+  });
+});
+
+test('create: records the creator as a member on disk, not only in memory', async () => {
+  const createRuntime = makeRuntimeFactory();
+  await withTmp(async (folder) => {
+    const admin = await Workspace.create({ createRuntime, folder, rootSeed: ROOT_SEED });
+    await admin.close();
+
+    // Asserted against the folder rather than a reopened handle, so a
+    // regression is reported as "nothing was persisted" rather than as a
+    // failure further downstream.
+    const bundle = await readBundleFolder(folder);
+    assert.equal(bundle.envelopes.length, 1);
+    const [selfEnvelope] = bundle.envelopes;
+    assert.ok(selfEnvelope, 'the creator should have an envelope written to disk');
+    assert.equal(selfEnvelope.recipient, didFromSeed(ROOT_SEED));
+  });
+});
+
 test('open without an envelope is rejected', async () => {
   const createRuntime = makeRuntimeFactory();
   await withTmp(async (folder) => {
@@ -216,5 +262,153 @@ test('a write by the admin propagates to an open member via change events', asyn
 
     await admin.close();
     await bob.close();
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// Local-first open (#313)
+// ---------------------------------------------------------------------------
+//
+// Measured on a cellular connection: opening the corestore takes 73 ms and
+// flushing the DHT announce takes 40 SECONDS. `create` and `open` awaited that
+// announce before returning, so every local operation waited on a network
+// round trip — which is not what local-first means.
+
+/** The standard fake, with `joinTopic` replaced. */
+function factoryWithJoin(
+  joinTopic: () => Promise<void>,
+  replicates?: boolean,
+): (opts: CreateRuntimeOptions) => Promise<P2PRuntime> {
+  const base = makeRuntimeFactory();
+  return async (opts) => {
+    const runtime = await base(opts);
+    return { ...runtime, joinTopic, ...(replicates === undefined ? {} : { replicates }) } as P2PRuntime;
+  };
+}
+
+test('create does not wait for the swarm announce', async () => {
+  // The announce never settles. If `create` awaited it this would hang rather
+  // than fail — which is exactly what the app did for 40 seconds.
+  let release: (() => void) | null = null;
+  const createRuntime = factoryWithJoin(
+    () => new Promise<void>((resolve) => { release = resolve; }),
+  );
+
+  await withTmp(async (folder) => {
+    const started = Date.now();
+    const ws = await Workspace.create({ createRuntime, folder, name: 'Acme', rootSeed: ROOT_SEED });
+    // Generous: the point is "did not wait for something that never happens",
+    // not a performance assertion that would flake on a loaded machine.
+    assert.ok(Date.now() - started < 5000, 'create returned without the announce');
+    assert.equal(ws.isAdmin, true, 'and the workspace is fully usable');
+    await ws.write(new TextEncoder().encode('a local write, with no network'));
+    assert.equal(ws.length, 1);
+    release?.();
+    await ws.close();
+  });
+});
+
+test('a failed announce does not fail the open, and stays observable', async () => {
+  // A restricted network is a normal condition — carrier NAT blocks the UDP
+  // hole-punching an announce needs — and must not deny someone their own
+  // files. But it has to be inspectable rather than silent, or "no peers
+  // nearby" and "never announced" look identical.
+  const createRuntime = factoryWithJoin(() => Promise.reject(new Error('no route to host')));
+
+  await withTmp(async (folder) => {
+    const ws = await Workspace.create({ createRuntime, folder, name: 'Acme', rootSeed: ROOT_SEED });
+    await assert.rejects(() => ws.announced, /no route to host/);
+    // Still fully usable.
+    await ws.write(new TextEncoder().encode('written anyway'));
+    assert.equal(ws.length, 1);
+    await ws.close();
+  });
+});
+
+test('a local-only runtime never announces, and resolves rather than throwing', async () => {
+  const createRuntime = factoryWithJoin(
+    () => Promise.reject(new Error('joinTopic must not be called on a local-only runtime')),
+    false,
+  );
+
+  await withTmp(async (folder) => {
+    const ws = await Workspace.create({ createRuntime, folder, name: 'Acme', rootSeed: ROOT_SEED });
+    await ws.announced; // resolves; would reject if joinTopic had been called
+    await ws.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// One root keypair per workspace (#317)
+// ---------------------------------------------------------------------------
+//
+// `workspace-format.md` resolves this explicitly: "Orgs with multiple
+// workspaces create multiple `.workspace` folders, each with its own root
+// keypair." The desktop app was passing the device's identity seed as the root
+// seed, so every workspace made on one machine had the same id — and since the
+// swarm topic is a hash of that id, the same topic too.
+
+test('two workspaces created from one device identity have different ids', async () => {
+  // The regression. `workspaceId` is the root public key, so a shared root
+  // seed is a shared identity: the sidebar deduped one away, and peers would
+  // have been told two different workspaces were the same one.
+  const DEVICE_SEED = new Uint8Array(32).fill(9);
+  const createRuntime = makeRuntimeFactory();
+
+  await withTmp(async (folder) => {
+    const a = await Workspace.create({ createRuntime, folder, name: 'A', identitySeed: DEVICE_SEED });
+    const b = await Workspace.create({
+      createRuntime,
+      folder: `${folder}-second`,
+      name: 'B',
+      identitySeed: DEVICE_SEED,
+    });
+
+    assert.notEqual(a.id, b.id, 'each workspace has its own root keypair');
+    // Same device, so the same peer identity in both — which is the point:
+    // one machine, many workspaces.
+    assert.equal(a.did, b.did);
+    assert.equal(a.did, didFromSeed(DEVICE_SEED));
+    await a.close();
+    await b.close();
+  });
+});
+
+test('the creator can reopen a workspace whose root is not their device key', async () => {
+  // The trap in this fix. `open` looks for an envelope addressed to the
+  // OPENING device; create used to address it to the root. That only worked
+  // while the two seeds were the same value, so making the root seed random
+  // without moving the envelope would have given unique ids and broken
+  // reopening — worse than the bug.
+  const DEVICE_SEED = new Uint8Array(32).fill(9);
+  const createRuntime = makeRuntimeFactory();
+
+  await withTmp(async (folder) => {
+    const created = await Workspace.create({
+      createRuntime,
+      folder,
+      name: 'Acme',
+      identitySeed: DEVICE_SEED,
+    });
+    const id = created.id;
+    await created.write(new TextEncoder().encode('before close'));
+    await created.close();
+
+    const reopened = await Workspace.open({ createRuntime, folder, identitySeed: DEVICE_SEED });
+    assert.equal(reopened.id, id, 'same workspace');
+    assert.equal(reopened.did, didFromSeed(DEVICE_SEED));
+    await reopened.close();
+  });
+});
+
+test('a workspace root identity is not the creator device identity', async () => {
+  const DEVICE_SEED = new Uint8Array(32).fill(9);
+  const createRuntime = makeRuntimeFactory();
+  await withTmp(async (folder) => {
+    const ws = await Workspace.create({ createRuntime, folder, name: 'Acme', identitySeed: DEVICE_SEED });
+    assert.notEqual(ws.did, ws.rootDid, 'the device is a member, not the workspace');
+    assert.equal(ws.did, didFromSeed(DEVICE_SEED));
+    await ws.close();
   });
 });

--- a/packages/workspace/tsconfig.json
+++ b/packages/workspace/tsconfig.json
@@ -2,9 +2,15 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "allowImportingTsExtensions": true,
     "noEmit": true
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": [
+    "src/**/*",
+    "tests/**/*",
+    "../p2p-runtime/src/*.d.ts"
+  ]
 }


### PR DESCRIPTION
The four packages were extracted into the Workspace monorepo and have been
developed there since. This repo is the public reference for the protocol,
so a reference that no longer matches the implementation is worse than no
reference.

52 files, +5,042 / −169.

## It also fixes a repo that did not typecheck

`develop` has **four typecheck errors** today — three unresolved
`react-native` imports and a duplicate `MacOSRuntimeOptions` export. That
was the state before this branch, not something the sync introduced.

| | before | after |
|---|---|---|
| typecheck | 4 errors | **exit 0** |
| tests | 110 passing | **187 passing**, 0 failing |

The duplicate export was local cruft the monorepo never had, so the sync
removes it. The `react-native` imports needed an actual decision.

## Two deliberate divergences

Both exist so this repo stays clonable and runnable with **no native
toolchain and no app framework** — which is the whole point of a reference.

1. **`src/ambient.react-native.d.ts`** declares the two symbols the macOS
   bridge imports, `NativeModules` and `NativeEventEmitter`, rather than
   taking a react-native dependency so that two files can typecheck. Only
   the surface actually used is declared, so widening it stays a visible
   decision rather than a quiet one.
2. **Sibling tsconfig includes widened** to `../p2p-runtime/src/*.d.ts`, so
   both ambient files are picked up when those packages typecheck
   p2p-runtime sources.

Credit where due: both were identified independently on the Fedora rig, in
an earlier sync attempt that this supersedes.

## What is new here

The Bare worklet path, the working-tree watcher, blobs, the store transport
form, the IPC framing and transports, the crypto shims, and the conformance
suite.

p2p-runtime's `exports` map is synced too, since the new subpaths are what
`@workspace.sh/workspace` imports. **Every target was checked to resolve** —
the old dangling `./node` export that pointed at a deleted file is already
gone upstream and is not reintroduced.

Each package's own `package.json` is otherwise untouched, preserving the
Apache-2.0 licence field p2p-runtime carries here and the monorepo does not.

## FINDINGS.md

Mobile is no longer true "by extension" — the Bare path runs on a physical
device, and a fourth client (GTK4 on Linux) consumes these same packages.
The extraction checklist is done, so it says so, and it now records the
direction of travel: code changes in the monorepo and flows here, so the
spec and the implementation cannot drift apart silently.